### PR TITLE
feat(cardano-node-api): add loadbalancer and secret support for TLS

### DIFF
--- a/.github/workflows/helmchart-testing.yml
+++ b/.github/workflows/helmchart-testing.yml
@@ -41,4 +41,7 @@ jobs:
     
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: |
+          ct install --target-branch ${{ github.event.repository.default_branch }}
+
+        

--- a/charts/cardano-node-api/Chart.yaml
+++ b/charts/cardano-node-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node-api
 description: Creates a Cardano Node API deployment
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.7.0
 maintainers:
   - name: aurora

--- a/charts/cardano-node-api/templates/deployment.yaml
+++ b/charts/cardano-node-api/templates/deployment.yaml
@@ -10,13 +10,15 @@ spec:
   selector:
     matchLabels:
       cardano_network: {{ .Values.cardano_network }}
-      app.kubernetes.io/name: {{ include "cardano-node-api.fullname" . }}
-{{ include "cardano-node-api.labels" . | indent 6 }}
+      app.kubernetes.io/name: {{ include "cardano-node-api.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      cardano_network: {{ include "cardano-node-api.network" . }}
+      cardano_service: cardano-node-api
   template:
     metadata:
       labels:
         cardano_network: {{ .Values.cardano_network }}
-        app.kubernetes.io/name: {{ include "cardano-node-api.fullname" . }}
 {{ include "cardano-node-api.labels" . | indent 8 }}
     spec:
       {{- if .Values.affinity }}
@@ -32,6 +34,12 @@ spec:
           value: {{ .Values.cardano_node.port | toString | quote }}
         - name: CARDANO_NODE_SKIP_CHECK
           value: {{ .Values.cardano_node.skip_check | quote }}
+        {{- if .Values.secret.enabled }}
+        - name: TLS_CERT_FILE_PATH
+          value: "/certs/tls.crt"
+        - name: TLS_KEY_FILE_PATH
+          value: "/certs/tls.key"
+        {{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: IfNotPresent
         name: cardano-node-api
@@ -42,17 +50,32 @@ spec:
           containerPort: 9090
         readinessProbe:
           httpGet:
+            {{- if .Values.secret.enabled }}
+            scheme: HTTPS
+            {{- else }}
+            scheme: HTTP
+            {{- end }}
             path: /healthcheck
             port: api
         resources: {{ .Values.resources | toYaml | nindent 10 }}
         volumeMounts:
         - mountPath: /node-ipc
           name: node-ipc
+      {{- if .Values.secret.enabled }}
+        - mountPath: /certs
+          name: certs
+      {{- end }}
       restartPolicy: Always
       serviceAccountName: ""
 {{- if .Values.tolerations }}
       tolerations: {{ .Values.tolerations | toYaml | nindent 8 }}
 {{- end }}
       volumes:
-      - emptyDir: {}
-        name: node-ipc
+      - name: node-ipc
+        emptyDir: {}
+    {{- if .Values.secret.enabled }}
+      - name: certs
+        secret:
+          optional: false
+          secretName: {{ include "cardano-node-api.fullname" . }}-tls
+    {{- end }}

--- a/charts/cardano-node-api/templates/secret.yaml
+++ b/charts/cardano-node-api/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.secret.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cardano-node-api.fullname" . }}-tls
+type: kubernetes.io/tls
+stringData:
+  tls.key: {{ .Values.secret.tlsKey | quote }} 
+  tls.crt: {{ .Values.secret.tlsCrt | quote }}
+{{- end }}

--- a/charts/cardano-node-api/templates/service.yaml
+++ b/charts/cardano-node-api/templates/service.yaml
@@ -1,19 +1,20 @@
+{{ if .Values.service.enabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.service.annotations }}
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ include "cardano-node-api.fullname" . }}
 {{ include "cardano-node-api.labels" . | indent 4 }}
   name: {{ include "cardano-node-api.fullname" . }}
 spec:
-  ports:
-  - name: api
-    port: 8080
-    protocol: TCP
-    targetPort: 8080
+  ports: {{ toYaml .Values.service.ports | nindent 2 }}
   selector:
     cardano_network: {{ .Values.cardano_network }}
-    app.kubernetes.io/name: {{ include "cardano-node-api.fullname" . }}
+    app.kubernetes.io/name: {{ include "cardano-node-api.name" . }}
   sessionAffinity: ClientIP
-  type: ClusterIP
+  type: {{ .Values.service.type }}
+{{- end }}

--- a/charts/cardano-node-api/values.yaml
+++ b/charts/cardano-node-api/values.yaml
@@ -1,4 +1,6 @@
 ---
+nameOverride: ""
+
 cardano_network: preview
 cardano_node:
   host: cardano-node-headless
@@ -7,9 +9,6 @@ cardano_node:
 image:
   repository: ghcr.io/blinklabs-io/cardano-node-api
   tag: 0.7.0
-ingress:
-  enabled: false
-  host: node-api.preview.local
 replicaCount: 1
 resources: {}
 tolerations:
@@ -17,3 +16,33 @@ tolerations:
   operator: Equal
   value: arm64
   effect: NoSchedule
+
+affinity: {}
+
+ingress:
+  enabled: false
+  host: node-api.preview.local
+  ingressClassName: kong
+
+service:
+  enabled: false
+  annotations: {}
+  ports:
+    - name: grpc
+      port: 443
+      protocol: TCP
+      targetPort: 9090
+  type: LoadBalancer
+
+# Example of a ClusterIP service
+  # ports:
+  # - name: api
+  #   port: 8080
+  #   protocol: TCP
+  #   targetPort: 8080
+  # type: ClusterIP
+
+secret:
+  enabled: false
+  # tlsKey: ""
+  # tlsCrt: ""


### PR DESCRIPTION
- Add support to adjust Service type to LoadBalancer and ports
- Add Secret support for TLS configuration
- Fix selector matcher to exclude version labels (immutable) during helm upgrade
- Adjust the Service selector to align with Pod labels