### PR TITLE
feat: add Chart for handshake node

### DIFF
--- a/.github/workflows/helmchart-testing.yml
+++ b/.github/workflows/helmchart-testing.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          ct install --debug --target-branch ${{ github.event.repository.default_branch }}
+          ct install --target-branch ${{ github.event.repository.default_branch }}
 
         

--- a/.github/workflows/helmchart-testing.yml
+++ b/.github/workflows/helmchart-testing.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          ct install --target-branch ${{ github.event.repository.default_branch }}
+          ct install --debug --target-branch ${{ github.event.repository.default_branch }}
 
         

--- a/charts/handshake-node/Chart.yaml
+++ b/charts/handshake-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: handshake-node
 description: Deploys a Handshake node for specified network
-version: 0.1.8
+version: 0.1.9
 appVersion: 7.0.1
 maintainers:
   - name: aurora

--- a/charts/handshake-node/Chart.yaml
+++ b/charts/handshake-node/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: handshake-node
+description: Deploys a Handshake node for specified network
+version: 0.1.8
+appVersion: 7.0.1
+maintainers:
+  - name: aurora
+    email: aurora@blinklabs.io
+  - name: verbotenj
+    email: verbotenj@blinklabs.io
+  - name: wolf31o2
+    email: wolf31o2@blinklabs.io
+  - name: overcookedpanda
+    email: overcookedpanda@blinklabs.io

--- a/charts/handshake-node/templates/_helpers.tpl
+++ b/charts/handshake-node/templates/_helpers.tpl
@@ -84,11 +84,7 @@ Define resource requirements based on network
 */}}
 {{- define "handshake-node.resources" -}}
 {{- $network := include "handshake-node.network" . -}}
-{{- if .Values.resources -}}
-{{- toYaml .Values.resources -}}
-{{- else -}}
-{{- toYaml (index .Values.networkResources $network) -}}
-{{- end -}}
+{{ toYaml (index .Values.networkResources $network) }}
 {{- end -}}
 
 {{/*

--- a/charts/handshake-node/templates/_helpers.tpl
+++ b/charts/handshake-node/templates/_helpers.tpl
@@ -1,0 +1,118 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "handshake-node.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "handshake-node.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Network-aware fullname
+*/}}
+{{- define "handshake-node.network-fullname" -}}
+{{- $name := include "handshake-node.fullname" . -}}
+{{- $network := include "handshake-node.network" . -}}
+{{- printf "%s-%s" $name $network -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "handshake-node.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Define Handshake network.
+*/}}
+{{- define "handshake-node.network" -}}
+{{- if .Values.handshake_network -}}
+{{ .Values.handshake_network }}
+{{- else -}}
+"main"
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define port helpers based on network
+*/}}
+{{- define "handshake-node.p2p-port" -}}
+{{- $network := include "handshake-node.network" . -}}
+{{- index .Values.networkPorts $network "p2p" -}}
+{{- end -}}
+
+{{- define "handshake-node.brontide-port" -}}
+{{- $network := include "handshake-node.network" . -}}
+{{- index .Values.networkPorts $network "brontide" -}}
+{{- end -}}
+
+{{- define "handshake-node.http-port" -}}
+{{- $network := include "handshake-node.network" . -}}
+{{- index .Values.networkPorts $network "http" -}}
+{{- end -}}
+
+{{- define "handshake-node.ns-port" -}}
+{{- $network := include "handshake-node.network" . -}}
+{{- index .Values.networkPorts $network "ns" -}}
+{{- end -}}
+
+{{- define "handshake-node.rs-port" -}}
+{{- $network := include "handshake-node.network" . -}}
+{{- index .Values.networkPorts $network "rs" -}}
+{{- end -}}
+
+{{/*
+Define resource requirements based on network
+*/}}
+{{- define "handshake-node.resources" -}}
+{{- $network := include "handshake-node.network" . -}}
+{{- if .Values.resources -}}
+{{- toYaml .Values.resources -}}
+{{- else -}}
+{{- toYaml (index .Values.networkResources $network) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define storage size based on network
+*/}}
+{{- define "handshake-node.storage-size" -}}
+{{- $network := include "handshake-node.network" . -}}
+{{- if .Values.storage.size -}}
+{{- .Values.storage.size -}}
+{{- else -}}
+{{- index .Values.networkStorage $network -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "handshake-node.labels" -}}
+app.kubernetes.io/name: {{ include "handshake-node.name" . }}
+helm.sh/chart: {{ include "handshake-node.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+handshake_network: {{ include "handshake-node.network" . }}
+{{- end -}}

--- a/charts/handshake-node/templates/statefulset.yaml
+++ b/charts/handshake-node/templates/statefulset.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    {{- include "handshake-node.labels" . | nindent 4 }}
+  name: {{ include "handshake-node.network-fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      handshake_network: {{ include "handshake-node.network" . }}
+      app.kubernetes.io/name: {{ include "handshake-node.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  serviceName: {{ include "handshake-node.network-fullname" . }}
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        kubectl.kubernetes.io/default-container: handshake-node
+      labels:
+        handshake_network: {{ include "handshake-node.network" . }}
+        app.kubernetes.io/name: {{ include "handshake-node.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "handshake-node.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        fsGroup: 1000
+      containers:
+      - name: handshake-node
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - --network={{ include "handshake-node.network" . }}
+        - --listen={{ .Values.nodeConfig.listen }}
+        - --max-inbound={{ .Values.nodeConfig.maxInbound }}
+        - --max-outbound={{ .Values.nodeConfig.maxOutbound }}
+        - --http-host={{ .Values.nodeConfig.httpHost }}
+        - --http-port={{ include "handshake-node.http-port" . }}
+        {{- if .Values.nodeConfig.api.secretName }}
+        - --api-key=$(HSD_API_KEY)
+        {{- end }}
+        {{- if .Values.nodeConfig.publicHost }}
+        - --public-host={{ .Values.nodeConfig.publicHost }}
+        {{- end }}
+        - --brontide-port={{ include "handshake-node.brontide-port" . }}
+        - --prune={{ .Values.nodeConfig.prune }}
+        - --index-tx={{ .Values.nodeConfig.indexTx }}
+        - --index-address={{ .Values.nodeConfig.indexAddress }}
+        - --checkpoints={{ .Values.nodeConfig.checkpoints }}
+        - --log-level={{ .Values.nodeConfig.logLevel }}
+        - --cors={{ .Values.nodeConfig.cors }}
+        {{- if .Values.nodeConfig.ssl }}
+        - --ssl=true
+        - --ssl-cert={{ .Values.nodeConfig.sslCert }}
+        - --ssl-key={{ .Values.nodeConfig.sslKey }}
+        {{- end }}
+        - --ns-host={{ .Values.nodeConfig.nsHost }}
+        - --ns-port={{ include "handshake-node.ns-port" . }}
+        - --rs-host={{ .Values.nodeConfig.rsHost }}
+        - --rs-port={{ include "handshake-node.rs-port" . }}
+        - --rs-no-unbound={{ .Values.nodeConfig.rsNoUnbound }}
+        env:
+        {{- if .Values.nodeConfig.api.secretName }}
+        - name: HSD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.nodeConfig.api.secretName }}
+              key: {{ .Values.nodeConfig.api.secretKey }}
+        {{ end }}
+        - name: HSD_NETWORK
+          value: "{{ include "handshake-node.network" . }}"
+        - name: HSD_PREFIX
+          value: "/data"
+        ports:
+        - name: p2p
+          containerPort: {{ include "handshake-node.p2p-port" . }}
+          protocol: TCP
+        - name: brontide
+          containerPort: {{ include "handshake-node.brontide-port" . }}
+          protocol: TCP
+        - name: http
+          containerPort: {{ include "handshake-node.http-port" . }}
+          protocol: TCP
+        - name: ns
+          containerPort: {{ include "handshake-node.ns-port" . }}
+          protocol: UDP
+        - name: rs
+          containerPort: {{ include "handshake-node.rs-port" . }}
+          protocol: UDP
+        resources:
+          {{- $network := include "handshake-node.network" . }}
+          {{- if .Values.resources }}
+          {{- toYaml .Values.resources | nindent 12 }}
+          {{- else }}
+          {{- toYaml (index .Values.networkResources $network) | nindent 12 }}
+          {{- end }}
+        volumeMounts:
+        - name: handshake-data-{{ include "handshake-node.network" . }}
+          mountPath: /data
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        handshake_network: {{ include "handshake-node.network" . }}
+      name: handshake-data-{{ include "handshake-node.network" . }}
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      {{- if .Values.storage.storageClassName }}
+      storageClassName: {{ .Values.storage.storageClassName }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ include "handshake-node.storage-size" . }}

--- a/charts/handshake-node/templates/tcp-service.yaml
+++ b/charts/handshake-node/templates/tcp-service.yaml
@@ -8,10 +8,11 @@ metadata:
     {{- if .Values.service.tcp.annotations }}
     {{- toYaml .Values.service.tcp.annotations | nindent 4 }}
     {{- end }}
-    cloud.google.com/load-balancer-type: "External"
 spec:
-  type: LoadBalancer
-  externalTrafficPolicy: Local
+  type: {{ .Values.service.tcp.type | default "ClusterIP" }}
+  {{- if eq (.Values.service.tcp.type | default "ClusterIP") "LoadBalancer" }}
+  externalTrafficPolicy: {{ .Values.service.tcp.externalTrafficPolicy | default "Cluster" }}
+  {{- end }}
   ports:
   - name: p2p
     port: {{ index .Values.networkPorts .Values.handshake_network "p2p" }}

--- a/charts/handshake-node/templates/tcp-service.yaml
+++ b/charts/handshake-node/templates/tcp-service.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "handshake-node.fullname" . }}-tcp
+  labels:
+    {{- include "handshake-node.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.service.tcp.annotations }}
+    {{- toYaml .Values.service.tcp.annotations | nindent 4 }}
+    {{- end }}
+    cloud.google.com/load-balancer-type: "External"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+  - name: p2p
+    port: {{ index .Values.networkPorts .Values.handshake_network "p2p" }}
+    targetPort: {{ index .Values.networkPorts .Values.handshake_network "p2p" }}
+    protocol: TCP
+  - name: brontide
+    port: {{ index .Values.networkPorts .Values.handshake_network "brontide" }}
+    targetPort: {{ index .Values.networkPorts .Values.handshake_network "brontide" }}
+    protocol: TCP
+  - name: http
+    port: {{ index .Values.networkPorts .Values.handshake_network "http" }}
+    targetPort: {{ index .Values.networkPorts .Values.handshake_network "http" }}
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "handshake-node.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/handshake-node/templates/udp-service.yaml
+++ b/charts/handshake-node/templates/udp-service.yaml
@@ -8,10 +8,11 @@ metadata:
     {{- if .Values.service.udp.annotations }}
     {{- toYaml .Values.service.udp.annotations | nindent 4 }}
     {{- end }}
-    cloud.google.com/load-balancer-type: "External"
 spec:
-  type: LoadBalancer
-  externalTrafficPolicy: Local
+  type: {{ .Values.service.udp.type | default "ClusterIP" }}
+  {{- if eq (.Values.service.udp.type | default "ClusterIP") "LoadBalancer" }}
+  externalTrafficPolicy: {{ .Values.service.udp.externalTrafficPolicy | default "Cluster" }}
+  {{- end }}
   ports:
   - name: ns
     port: {{ index .Values.networkPorts .Values.handshake_network "ns" }}

--- a/charts/handshake-node/templates/udp-service.yaml
+++ b/charts/handshake-node/templates/udp-service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "handshake-node.fullname" . }}-udp
+  labels:
+    {{- include "handshake-node.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.service.udp.annotations }}
+    {{- toYaml .Values.service.udp.annotations | nindent 4 }}
+    {{- end }}
+    cloud.google.com/load-balancer-type: "External"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+  - name: ns
+    port: {{ index .Values.networkPorts .Values.handshake_network "ns" }}
+    targetPort: {{ index .Values.networkPorts .Values.handshake_network "ns" }}
+    protocol: UDP
+  - name: rs
+    port: {{ index .Values.networkPorts .Values.handshake_network "rs" }}
+    targetPort: {{ index .Values.networkPorts .Values.handshake_network "rs" }}
+    protocol: UDP
+  selector:
+    app.kubernetes.io/name: {{ include "handshake-node.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/handshake-node/values.yaml
+++ b/charts/handshake-node/values.yaml
@@ -95,8 +95,8 @@ nodeConfig:
   sslCert: ""
   sslKey: ""
   api:
-    secretName: "handshake-node-http-api-key"
-    secretKey: "apiKey"
+    secretName:
+    secretKey:
 
   # DNS server configs
   nsHost: "0.0.0.0"

--- a/charts/handshake-node/values.yaml
+++ b/charts/handshake-node/values.yaml
@@ -1,6 +1,6 @@
 ---
 # Network configuration (main for mainnet, testnet for testnet, regtest, etc.)
-handshake_network: regtest
+handshake_network: main
 
 networkPorts:
   main:

--- a/charts/handshake-node/values.yaml
+++ b/charts/handshake-node/values.yaml
@@ -95,8 +95,8 @@ nodeConfig:
   sslCert: ""
   sslKey: ""
   api:
-    secretName:
-    secretKey:
+    secretName: "handshake-node-http-api-key"
+    secretKey: "apiKey"
 
   # DNS server configs
   nsHost: "0.0.0.0"

--- a/charts/handshake-node/values.yaml
+++ b/charts/handshake-node/values.yaml
@@ -1,0 +1,123 @@
+---
+# Network configuration (main for mainnet, testnet for testnet, regtest, etc.)
+handshake_network: main
+
+networkPorts:
+  main:
+    p2p: 12038
+    brontide: 44806
+    http: 12037
+    ns: 5349
+    rs: 5350
+  testnet:
+    p2p: 13038
+    brontide: 45806
+    http: 13037
+    ns: 15349
+    rs: 15350
+  regtest:
+    p2p: 14038
+    brontide: 46806
+    http: 14037
+    ns: 25349
+    rs: 25350
+  simnet:
+    p2p: 15038
+    brontide: 47806
+    http: 15037
+    ns: 35349
+    rs: 35350
+
+networkResources:
+  main:
+    requests:
+      memory: "2Gi"
+      cpu: "1000m"
+    limits:
+      memory: "4Gi"
+      cpu: "2000m"
+  testnet:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "1000m"
+  regtest:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+  simnet:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
+networkStorage:
+  main: "200Gi"
+  testnet: "100Gi"
+  regtest: "20Gi"
+  simnet: "20Gi"
+
+image:
+  repository: ghcr.io/handshake-org/hsd
+  tag: 7.0.1
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# Node configuration
+nodeConfig:
+  # Chain options
+  prune: false
+  indexTx: false
+  indexAddress: false
+  checkpoints: true
+
+  # Logging options
+  logLevel: "info"
+
+  # Network options
+  listen: true
+  maxInbound: 50
+  maxOutbound: 8
+  publicHost: ""
+
+  # HTTP API configuration
+  httpHost: "0.0.0.0"
+  cors: false
+  ssl: false
+  sslCert: ""
+  sslKey: ""
+  api:
+    secretName:
+    secretKey:
+
+  # DNS server configs
+  nsHost: "0.0.0.0"
+  rsHost: "0.0.0.0"
+  rsNoUnbound: false
+
+# Override default network resources if needed
+resources: {}
+
+# Service configurations
+service:
+  tcp:
+    annotations: {}
+  udp:
+    annotations: {}
+
+# Override default network storage size if needed
+storage:
+  storageClassName: ""
+
+# Pod scheduling configuration
+affinity: {}
+nodeSelector: {}
+tolerations: []

--- a/charts/handshake-node/values.yaml
+++ b/charts/handshake-node/values.yaml
@@ -1,6 +1,6 @@
 ---
 # Network configuration (main for mainnet, testnet for testnet, regtest, etc.)
-handshake_network: main
+handshake_network: regtest
 
 networkPorts:
   main:

--- a/charts/handshake-node/values.yaml
+++ b/charts/handshake-node/values.yaml
@@ -103,9 +103,6 @@ nodeConfig:
   rsHost: "0.0.0.0"
   rsNoUnbound: false
 
-# Override default network resources if needed
-resources: {}
-
 # Service configurations
 service:
   tcp:


### PR DESCRIPTION
This chart can be used to deploy the handshake node for all networks `main | testnet | regtest | simnet` and can support multiple deployments into a single cluster with resources named appropriately for each network.  It expects a secret to reside in the cluster named `handshake-node-http-api-key` with key `apiKey` which is used for authentication with the http api.

I'm not entirely sure of the resource requirements needed for the different networks, so those values may need to be updated before deployment.
