### PR TITLE
fix(cardano-node): fix statefulset remove immutable labels from selector

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.1.17
+version: 0.1.18
 appVersion: 10.3.1
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/_helpers.tpl
+++ b/charts/cardano-node/templates/_helpers.tpl
@@ -57,3 +57,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 cardano_network: {{ include "cardano-node.network" . }}
 cardano_service: cardano-node
 {{- end -}}
+
+{{/*
+Cardano node selector labels
+*/}}
+{{- define "cardano-node.matchLabels" -}}
+app.kubernetes.io/name: {{ include "cardano-node.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+cardano_network: {{ include "cardano-node.network" . }}
+cardano_service: cardano-node
+{{- end -}}

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
-    matchLabels: {{ include "cardano-node.labels" . | nindent 6 }}
+    matchLabels: {{ include "cardano-node.matchLabels" . | nindent 6 }}
   serviceName: {{ include "cardano-node.fullname" . }}-headless
   template:
     metadata:


### PR DESCRIPTION
The `helm.sh/chart` and `app.kubernetes.io/version` labels were dropped from `.spec.selector.matchLabels` to avoid Kubernetes immutability errors on upgrades.