### PR TITLE
feat(cardano-node): add extra labels and use matchLabels helper in Po…

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.1.19
+version: 0.1.20
 appVersion: 10.3.1
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/podmonitor.yaml
+++ b/charts/cardano-node/templates/podmonitor.yaml
@@ -6,11 +6,13 @@ metadata:
   name: {{ include "cardano-node.fullname" . }}
   labels:
     {{- include "cardano-node.labels" . | nindent 4 }}
+{{- with .Values.podMonitor.extraLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "cardano-node.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "cardano-node.matchLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/cardano-node/values.yaml
+++ b/charts/cardano-node/values.yaml
@@ -33,6 +33,7 @@ tolerations:
 # Enable the PodMonitor for Prometheus Operator
 podMonitor:
   enabled: false
+  # extraLabels: {}
   podMetricsEndpoints:
     - port: metrics
       path: /metrics


### PR DESCRIPTION
…dMonitor

Test Template
```
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: preview-cardano-node
  labels:
    app.kubernetes.io/name: preview-cardano-node
    helm.sh/chart: cardano-node-0.1.20
    app.kubernetes.io/instance: preview
    app.kubernetes.io/version: "10.3.1"
    app.kubernetes.io/managed-by: Helm
    cardano_network: preview
    cardano_service: cardano-node
    extra-label: test
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: preview-cardano-node
      app.kubernetes.io/instance: preview
      cardano_network: preview
      cardano_service: cardano-node
  namespaceSelector:
    matchNames:
      - default
  podMetricsEndpoints:
    - interval: 30s
      path: /metrics
      port: metrics
  ```