### PR TITLE
fix(ci): fix publishing Dingo chart

### DIFF
--- a/.github/workflows/publish-dingo-helm-chart.yml
+++ b/.github/workflows/publish-dingo-helm-chart.yml
@@ -26,7 +26,7 @@ jobs:
           rm -rf dist
           mkdir dist
           helm package charts/dingo/ -d dist/
-          echo "${TOKEN}" | helm registry login "${REGISTRY}/${REPOSITORY,,}" -u "${USER}" --password-stdin
+          echo "${TOKEN}" | helm registry login "${REGISTRY}" -u "${USER}" --password-stdin
           for file in dist/*; do
             helm push "$file" "oci://${REGISTRY}/${REPOSITORY,,}/charts"
           done


### PR DESCRIPTION
Based on documentation only host should be specified
https://helm.sh/docs/helm/helm_registry_login/