### PR TITLE
fix(postgres-cluster): comment out default values

### DIFF
--- a/charts/postgres-cluster/Chart.yaml
+++ b/charts/postgres-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: postgesql-cluster
 description: "A Helm chart to deploy CR postgresql for Zolando PostgresSQL Operator"
-version: 0.0.1
+version: 0.0.2
 appVersion: "17"
 
 sources:

--- a/charts/postgres-cluster/templates/cluster.yaml
+++ b/charts/postgres-cluster/templates/cluster.yaml
@@ -7,5 +7,4 @@ metadata:
   {{- with .Values.labels }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}
-spec:
-  {{- toYaml .Values.spec | nindent 2 }}
+spec: {{- toYaml .Values.spec | nindent 2 }}

--- a/charts/postgres-cluster/values.yaml
+++ b/charts/postgres-cluster/values.yaml
@@ -1,21 +1,19 @@
 ---
-apiVersion: "acid.zalan.do/v1"
-kind: postgresql
-metadata:
-  name: acid-minimal-cluster
-spec:
-  teamId: "acid"
-  volume:
-    size: 5Gi
-  numberOfInstances: 2
-  users:
-    zalando:  # database owner
-    - superuser
-    - createdb
-    foo_user: []  # role for application foo
-  databases:
-    foo: zalando  # dbname: owner
-  preparedDatabases:
-    bar: {}
-  postgresql:
-    version: "17"
+labels: {}
+spec: {}
+# Minimum example of a PostgreSQL cluster
+  # teamId: "acid"
+  # volume:
+  #   size: 5Gi
+  # numberOfInstances: 2
+  # users:
+  #   zalando:  # database owner
+  #   - superuser
+  #   - createdb
+  #   foo_user: []  # role for application foo
+  # databases:
+  #   foo: zalando  # dbname: owner
+  # preparedDatabases:
+  #   bar: {}
+  # postgresql:
+  #   version: "17"


### PR DESCRIPTION
- commented out because they appear due to chart usage and deep merge behavior
- remove k8s resource definition header