### PR TITLE
feat(bind9): allow setting loadBalancerIP on services

### DIFF
--- a/charts/bind9/Chart.yaml
+++ b/charts/bind9/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bind9
 description: "A Helm chart for deploying BIND9 DNS resolver"
-version: 0.0.3
+version: 0.0.4
 appVersion: "9.18"
 
 sources:

--- a/charts/bind9/templates/dns-service.yaml
+++ b/charts/bind9/templates/dns-service.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+{{- if and (eq .Values.service.type "LoadBalancer") (hasKey .Values.service "loadBalancerIP") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
   ports:
     - port: {{ .Values.service.tcp.port }}
       targetPort: {{ .Values.bind9.internalPort }}

--- a/charts/bind9/templates/tcp-service.yaml
+++ b/charts/bind9/templates/tcp-service.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.tcp.type }}
+{{- if and (eq .Values.service.tcp.type "LoadBalancer") (hasKey .Values.service.tcp "loadBalancerIP") }}
+  loadBalancerIP: {{ .Values.service.tcp.loadBalancerIP }}
+{{- end }}
   ports:
     - port: {{ .Values.service.tcp.port }}
       targetPort: {{ .Values.bind9.internalPort }}

--- a/charts/bind9/templates/udp-service.yaml
+++ b/charts/bind9/templates/udp-service.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.udp.type }}
+{{- if and (eq .Values.service.udp.type "LoadBalancer") (hasKey .Values.service.udp "loadBalancerIP") }}
+  loadBalancerIP: {{ .Values.service.udp.loadBalancerIP }}
+{{- end }}
   ports:
     - port: {{ .Values.service.udp.port }}
       targetPort: {{ .Values.bind9.internalPort }}


### PR DESCRIPTION
This allows setting the IP address. On GCP, this allows us to set the same IP address for TCP and UDP load balancers, putting DNS on a single inbound IP instead of split across two based on protocol.