### PR TITLE
fix(openvpn): use consistent pull policy variable naming

### DIFF
--- a/charts/openvpn/Chart.yaml
+++ b/charts/openvpn/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openvpn
 description: A Helm chart for deploying OpenVPN in Kubernetes with an optional BIND sidecar
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "0.4.0"
 
 maintainers:

--- a/charts/openvpn/templates/deployment.yaml
+++ b/charts/openvpn/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
         {{- if .Values.bind.enabled }}
         - name: bind
           image: "{{ .Values.bind.image.repository }}:{{ .Values.bind.image.tag }}"
-          imagePullPolicy: {{ .Values.bind.image.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.bind.image.pullPolicy }}
           env:
             - name: POD_IP
               valueFrom:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected image pull policy configuration in the deployment template to align with expected Helm values.

* **Chores**
  * Updated Helm chart version to 0.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->