### PR TITLE
feat: add butane-oracle chart

### DIFF
--- a/.github/workflows/publish-butane-oracle-helm-chart.yml
+++ b/.github/workflows/publish-butane-oracle-helm-chart.yml
@@ -1,0 +1,36 @@
+name: publish-butane-oracle-helm-chart
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      [
+        "charts/butane-oracle/**",
+        ".github/workflows/publish-butane-oracle-helm-chart.yml",
+      ]
+
+jobs:
+  build-and-push-butane-oracle-helm-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      - name: Package and upload chart
+        shell: bash
+        env:
+          REGISTRY: "ghcr.io"
+          REPOSITORY: "${{ github.repository }}"
+          TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          USER: "${{ github.repository_owner }}"
+        run: |
+          rm -rf dist
+          mkdir dist
+          helm package charts/butane-oracle/ -d dist/
+          echo "${TOKEN}" | helm registry login "${REGISTRY}" -u "${USER}" --password-stdin
+          for file in dist/*; do
+            helm push "$file" "oci://${REGISTRY}/${REPOSITORY,,}/charts"
+          done

--- a/charts/butane-oracle/Chart.yaml
+++ b/charts/butane-oracle/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: butane-oracle
+description: Helm chart for SundaeSwap butane-oracle
+version: 0.1.0
+appVersion: "v0.25.1"
+type: application
+maintainers:
+  - name: aurora
+    email: aurora@blinklabs.io
+  - name: overcookedpanda
+    email: overcookedpanda@blinklabs.io
+  - name: verbotenj
+    email: verbotenj@blinklabs.io
+  - name: wolf31o2
+    email: wolf31o2@blinklabs.io

--- a/charts/butane-oracle/templates/_helpers.tpl
+++ b/charts/butane-oracle/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "butane-oracle.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "butane-oracle.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "butane-oracle.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "butane-oracle.labels" -}}
+app.kubernetes.io/name: {{ include "butane-oracle.name" . }}
+helm.sh/chart: {{ include "butane-oracle.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+butane-oracle selector labels
+*/}}
+{{- define "butane-oracle.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "butane-oracle.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/butane-oracle/templates/configmap.yaml
+++ b/charts/butane-oracle/templates/configmap.yaml
@@ -1,0 +1,13 @@
+---
+{{- if .Values.config.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels: {{- include "butane-oracle.labels" . | nindent 4 }}
+  name: {{ include "butane-oracle.fullname" . }}-config
+  annotations:
+    checksum/config: {{ .Values.config.configYaml | sha256sum }}
+data:
+  config.yaml: |
+{{ .Values.config.configYaml | indent 4 }}
+{{- end }}

--- a/charts/butane-oracle/templates/deployment.yaml
+++ b/charts/butane-oracle/templates/deployment.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "butane-oracle.fullname" . }}
+  labels:
+    {{- include "butane-oracle.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "butane-oracle.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "butane-oracle.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: butane-oracle
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        workingDir: /app
+        command: {{ toJson .Values.command }}
+        env:
+        {{- range $k, $v := .Values.env }}
+        - name: {{ $k }}
+          value: "{{ $v }}"
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.ports.http }}
+        - name: p2p
+          containerPort: {{ .Values.ports.p2p }}
+        - name: health
+          containerPort: {{ .Values.ports.health }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.probes.readiness.path }}
+            port: health
+          initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.probes.liveness.path }}
+            port: health
+          initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+        volumeMounts:
+        {{- if .Values.config.enabled }}
+        - name: config
+          mountPath: /data/config.yaml
+          readOnly: true
+        {{- end }}
+        {{- if and .Values.secrets.fxrates.enabled .Values.secrets.fxrates.name }}
+        - name: fxrates
+          mountPath: {{ .Values.secrets.fxrates.mountPath }}
+          readOnly: true
+        {{- end }}
+        {{- if and .Values.secrets.keys.enabled .Values.secrets.keys.name }}
+        - name: keys-app
+          mountPath: {{ .Values.secrets.keys.mountPathApp }}
+          readOnly: true
+        {{- end }}
+        resources: {{ toYaml .Values.resources | nindent 10 }}
+      volumes:
+      {{- if .Values.config.enabled }}
+      - name: config
+        configMap:
+          name: {{ include "butane-oracle.fullname" . }}-config
+      {{- end }}
+      {{- if and .Values.secrets.fxrates.enabled .Values.secrets.fxrates.name }}
+      - name: fxrates
+        secret:
+          secretName: {{ .Values.secrets.fxrates.name }}
+          items:
+          {{- range .Values.secrets.fxrates.data }}
+          - key: {{ .key }}
+            path: {{ .path | default .key }}
+          {{- end }}
+      {{- end }}
+      {{- if and .Values.secrets.keys.enabled .Values.secrets.keys.name }}
+      - name: keys-app
+        secret:
+          secretName: {{ .Values.secrets.keys.name }}
+          defaultMode: {{ .Values.secrets.keys.defaultMode }}
+          items:
+          {{- range .Values.secrets.keys.data }}
+          - key: {{ .key }}
+            path: {{ .path | default .key }}
+          {{- end }}
+      {{- end }}

--- a/charts/butane-oracle/templates/podmonitor.yaml
+++ b/charts/butane-oracle/templates/podmonitor.yaml
@@ -1,0 +1,20 @@
+---
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "butane-oracle.fullname" . }}
+  labels:
+    {{- include "butane-oracle.labels" . | nindent 4 }}
+{{- with .Values.podMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "butane-oracle.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    {{- toYaml .Values.podMonitor.podMetricsEndpoints | nindent 4 }}
+{{- end }}

--- a/charts/butane-oracle/templates/secret.yaml
+++ b/charts/butane-oracle/templates/secret.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.secrets.fxrates.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.fxrates.name }}
+  labels: {{ include "butane-oracle.labels" . | nindent 4 }}
+  annotations:
+    checksum/data: {{ toJson .Values.secrets.fxrates.data | sha256sum }}
+type: Opaque
+data:
+{{- range .Values.secrets.fxrates.data }}
+  {{ .key }}: {{ .value | b64enc }}
+{{- end }}
+{{- end }}
+{{- if .Values.secrets.keys.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.keys.name }}
+  labels: {{ include "butane-oracle.labels" . | nindent 4 }}
+  annotations:
+    checksum/data: {{ toJson .Values.secrets.keys.data | sha256sum }}
+type: Opaque
+data:
+{{- range .Values.secrets.keys.data }}
+  {{ .key }}: {{ .value | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/butane-oracle/templates/service.yaml
+++ b/charts/butane-oracle/templates/service.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.service.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.service.annotations }}
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
+  labels: {{- include "butane-oracle.labels" . | nindent 4 }}
+  name: {{ include "butane-oracle.fullname" . }}
+spec:
+  ports: {{ toYaml .Values.service.ports | nindent 2 }}
+  selector: {{ include "butane-oracle.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+{{- end }}

--- a/charts/butane-oracle/values.yaml
+++ b/charts/butane-oracle/values.yaml
@@ -1,0 +1,117 @@
+---
+# Override the name of the chart
+nameOverride: ""
+
+# Override the full name of the app
+fullnameOverride: ""
+
+image:
+  repository: "sundae/oracle"
+  tag: "v0.25.1"
+  pullPolicy: IfNotPresent
+
+command: ["./oracles", "-c", "/data/config.yaml"]
+
+# Ports
+ports:
+  http: 8080
+  p2p: 31415
+  health: 18000
+
+# Service
+service:
+  enabled: true
+  annotations: {}
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+    protocol: TCP
+  - name: p2p
+    port: 31415
+    targetPort: p2p
+    protocol: TCP
+  - name: health
+    port: 18000
+    targetPort: health
+    protocol: TCP
+
+# PodMonitor for Prometheus
+podMonitor:
+  enabled: false
+  extraLabels: {}
+  podMetricsEndpoints:
+  - port: health
+    path: /metrics
+    interval: 30s
+
+# ConfigMap content for config.yaml
+config:
+  enabled: true
+  configYaml: |
+    logs:
+      json: false
+      level: info
+
+secrets:
+  fxrates:
+    # If enabled it creates a secret for fxrates api key
+    enabled: true
+    name: fxrates-api
+    # Data for the secret
+    data:
+    - key: "fxrates-api.txt"
+      value: "FXRATESAPI_API_KEY=123123123"
+    mountPath: /data/butane
+  keys:
+    # If enabled it creates a secret for butane keys
+    enabled: true
+    name: butane-keys
+    mountPathApp: /app/keys
+    defaultMode: 0755
+    # Data for the secret
+    data:
+    - key: "public.pem"
+      value: "value"
+    - key: "private.pem"
+      value: "value"
+    - key: "another.vkey"
+      path: "another/another.vkey"
+      value: "value"
+
+# Environment
+env: {}
+  # TEST_ENV_VAR: "value"
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 25m
+    memory: 32Mi
+
+# Pod security context
+securityContext: {}
+  # fsGroup: 0
+  # runAsUser: 0
+  # runAsNonRoot: false
+
+affinity: {}
+nodeSelector: {}
+tolerations: []
+
+probes:
+  liveness:
+    path: /health
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readiness:
+    path: /health
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart for butane-oracle (v0.1.0, appVersion v0.25.1) for Kubernetes deployments
  * Includes Deployment, Service, ConfigMap, Secrets, and optional PodMonitor for Prometheus
  * Helpers and values.yaml enable configurable service endpoints, env vars, resource limits, probes, security, and volume mounts

* **Chores**
  * Automated workflow to package and publish the Helm chart to the OCI registry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->