### PR TITLE
chore: cardano-node 10.5.3

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.6.0
-appVersion: 10.5.1
+version: 0.6.1
+appVersion: 10.5.3
 maintainers:
   - name: aurora
     email: aurora@blinklabs.io

--- a/charts/cardano-node/values.yaml
+++ b/charts/cardano-node/values.yaml
@@ -3,7 +3,7 @@ cardano_network: preview
 # extraPodLabels: {}
 image:
   repository: ghcr.io/blinklabs-io/cardano-node
-  tag: 10.5.1
+  tag: 10.5.3
   pullPolicy: IfNotPresent
 replicaCount: 1
 resources: {}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade cardano-node Helm chart to use cardano-node 10.5.3 so new deployments run the latest patch. Bumps chart version to 0.6.1 and updates appVersion and image tag to 10.5.3.

<sup>Written for commit 7a869867a8ae7fc4307753355b5bb556a06a9f2e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 0.6.1 with application version 10.5.3
  * Updated container image to latest version (10.5.3)
  * Expanded maintainers list for improved support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->