### PR TITLE
fix(cardano-node): default config location using if

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.6.1
+version: 0.6.2
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -29,7 +29,11 @@ spec:
         - run
         env:
         - name: CARDANO_CONFIG
-          value: {{ .Values.cardano_config | default "/opt/cardano/config/{{ .Values.cardano_network }}/config.json" }}
+{{- if .Values.cardano_config }}
+          value: {{ .Values.cardano_config }}
+{{- else }}
+          value: "/opt/cardano/config/{{ .Values.cardano_network }}/config.json"
+{{- end }}
         - name: CARDANO_DATABASE_PATH
           value: /data/db
         - name: CARDANO_NETWORK


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix default CARDANO_CONFIG resolution in the cardano-node chart by using an explicit if/else to avoid Helm templating issues. When cardano_config is unset, the default path now correctly includes cardano_network; bumps chart to 0.6.2.

<sup>Written for commit 2c3f2da98eb6175baa40559336383339e9d2d5d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional CARDANO_CONFIG override in Cardano Node deployment configuration.

* **Chores**
  * Bumped Helm chart version to 0.6.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->