### PR TITLE
fix(cardano-node): configure socket path env var for clients

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.6.2
+version: 0.6.3
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -38,6 +38,8 @@ spec:
           value: /data/db
         - name: CARDANO_NETWORK
           value: "{{ .Values.cardano_network }}"
+        - name: CARDANO_NODE_SOCKET_PATH
+          value: /ipc/node.socket
         - name: CARDANO_PORT
           value: "{{ .Values.service.ports.ntn.targetPort }}"
         - name: CARDANO_SOCKET_PATH


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set CARDANO_NODE_SOCKET_PATH=/ipc/node.socket in the cardano-node StatefulSet so client tools that expect this env var can reliably find the node socket. Bumped chart version to 0.6.3.

<sup>Written for commit 67efc7f591f1d9d66dbe506b46a49c8bbedf6116. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Chart version updated to 0.6.3
  * Added socket path environment variable configuration to node deployment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->