### PR TITLE
feat(cardano-node): service-annotation-support

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.6.3
+version: 0.6.4
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/service.yaml
+++ b/charts/cardano-node/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
 {{ include "cardano-node.labels" . | indent 4 }}
   name: {{ include "cardano-node.fullname" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
   ports:
   - name: ntn

--- a/charts/cardano-node/values.yaml
+++ b/charts/cardano-node/values.yaml
@@ -8,6 +8,9 @@ image:
 replicaCount: 1
 resources: {}
 service:
+# Optional annotations for the Service
+# annotations:
+#   external-dns.alpha.kubernetes.io/hostname: "my-service.example.com"
   type: ClusterIP
   ports:
     ntn:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add optional Service annotations to the cardano-node Helm chart via values.service.annotations so you can attach metadata for tools like external-dns. Bumps chart version to 0.6.4.

<sup>Written for commit 6edbdf6d7b55c2eccc51be47563a552133216f0a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional Service annotations to enable flexible customization of Kubernetes Service metadata.

* **Chores**
  * Bumped Helm chart version to 0.6.4.
  * Added documented example configuration for Service annotations in chart values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->