### PR TITLE
fix(butane-oracle): fix secrets,config map handling and image reposit…

### DIFF
--- a/charts/butane-oracle/Chart.yaml
+++ b/charts/butane-oracle/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: butane-oracle
 description: Helm chart for SundaeSwap butane-oracle
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.25.1"
 type: application
 maintainers:

--- a/charts/butane-oracle/templates/deployment.yaml
+++ b/charts/butane-oracle/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         volumeMounts:
         {{- if .Values.config.enabled }}
         - name: config
-          mountPath: /data/config.yaml
+          mountPath: /data
           readOnly: true
         {{- end }}
         {{- if and .Values.secrets.fxrates.enabled .Values.secrets.fxrates.name }}

--- a/charts/butane-oracle/templates/secret.yaml
+++ b/charts/butane-oracle/templates/secret.yaml
@@ -25,6 +25,10 @@ metadata:
 type: Opaque
 data:
 {{- range .Values.secrets.keys.data }}
-  {{ .key }}: {{ .value | b64enc }}
+  {{- if .encodedValue }}
+    {{ .key }}: {{ .encodedValue }}
+  {{- else }}
+    {{ .key }}: {{ .value | b64enc }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/butane-oracle/values.yaml
+++ b/charts/butane-oracle/values.yaml
@@ -6,7 +6,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: "sundae/oracle"
+  repository: "sundaeswap/butane-oracle"
   tag: "v0.25.1"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
…ory/name

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Helm chart config and secrets handling, and points to the correct image repository. Bumps chart to 0.1.1.

- **Bug Fixes**
  - Mount ConfigMap at /data (was /data/config.yaml) so files load correctly.
  - Secret template supports encodedValue; otherwise base64-encodes value.
  - Set image.repository to sundaeswap/butane-oracle.

<sup>Written for commit 83a38fd5d18893b844a8b196df74f5f166b35cb9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped chart version to 0.1.1

* **New Features**
  * Added support for pre-encoded secret values, enabling flexible secret configuration while maintaining backward compatibility

* **Updates**
  * Updated container image reference for deployment
  * Modified configuration volume mount path for improved data management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->