### PR TITLE
fix(butane-oracle): fix selector labels

### DIFF
--- a/charts/butane-oracle/Chart.yaml
+++ b/charts/butane-oracle/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: butane-oracle
 description: Helm chart for SundaeSwap butane-oracle
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.25.1"
 type: application
 maintainers:

--- a/charts/butane-oracle/templates/_helpers.tpl
+++ b/charts/butane-oracle/templates/_helpers.tpl
@@ -42,6 +42,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 butane-oracle selector labels
 */}}
 {{- define "butane-oracle.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "butane-oracle.fullname" . }}
+app.kubernetes.io/name: {{ include "butane-oracle.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected Helm selector labels in the butane-oracle chart to use the chart name so Services/Deployments match pods correctly. Bumped chart version to 0.1.2.

<sup>Written for commit fcd6abdb4462c7bfb0644be9133c8122719eb88e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to 0.1.2
  * Updated Kubernetes selector label configuration for improved service identification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->