### PR TITLE
fix(butane-oracle): fix secret names to use release name prefix

### DIFF
--- a/charts/butane-oracle/Chart.yaml
+++ b/charts/butane-oracle/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: butane-oracle
 description: Helm chart for SundaeSwap butane-oracle
-version: 0.1.2
+version: 0.1.3
 appVersion: "v0.25.1"
 type: application
 maintainers:

--- a/charts/butane-oracle/templates/deployment.yaml
+++ b/charts/butane-oracle/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
       {{- if and .Values.secrets.fxrates.enabled .Values.secrets.fxrates.name }}
       - name: fxrates
         secret:
-          secretName: {{ .Values.secrets.fxrates.name }}
+          secretName: {{ .Release.Name }}-fxrates
           items:
           {{- range .Values.secrets.fxrates.data }}
           - key: {{ .key }}
@@ -101,7 +101,7 @@ spec:
       {{- if and .Values.secrets.keys.enabled .Values.secrets.keys.name }}
       - name: keys-app
         secret:
-          secretName: {{ .Values.secrets.keys.name }}
+          secretName: {{ .Release.Name }}-keys
           defaultMode: {{ .Values.secrets.keys.defaultMode }}
           items:
           {{- range .Values.secrets.keys.data }}

--- a/charts/butane-oracle/templates/secret.yaml
+++ b/charts/butane-oracle/templates/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secrets.fxrates.name }}
+  name: {{ .Release.Name }}-fxrates
   labels: {{ include "butane-oracle.labels" . | nindent 4 }}
   annotations:
     checksum/data: {{ toJson .Values.secrets.fxrates.data | sha256sum }}
@@ -18,7 +18,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secrets.keys.name }}
+  name: {{ .Release.Name }}-keys
   labels: {{ include "butane-oracle.labels" . | nindent 4 }}
   annotations:
     checksum/data: {{ toJson .Values.secrets.keys.data | sha256sum }}

--- a/charts/butane-oracle/values.yaml
+++ b/charts/butane-oracle/values.yaml
@@ -58,7 +58,6 @@ secrets:
   fxrates:
     # If enabled it creates a secret for fxrates api key
     enabled: true
-    name: fxrates-api
     # Data for the secret
     data:
     - key: "fxrates-api.txt"
@@ -67,7 +66,6 @@ secrets:
   keys:
     # If enabled it creates a secret for butane keys
     enabled: true
-    name: butane-keys
     mountPathApp: /app/keys
     defaultMode: 0755
     # Data for the secret


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix secret naming to use the Helm release prefix, preventing name collisions and ensuring mounts resolve correctly.

- **Bug Fixes**
  - Secrets now use {{ .Release.Name }}-fxrates and {{ .Release.Name }}-keys.
  - Deployment secret mounts updated to match.
  - Removed custom secret name fields and bumped chart version to 0.1.3.

<sup>Written for commit 48c747a6a871f5bb32364174ca84180d5d826dc9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped chart version to 0.1.3
  * Updated secret naming conventions to use release name instead of explicit configuration values

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->