### PR TITLE
fix(butane-oracle): fix remove conditioning from required configuration

### DIFF
--- a/charts/butane-oracle/Chart.yaml
+++ b/charts/butane-oracle/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: butane-oracle
 description: Helm chart for SundaeSwap butane-oracle
-version: 0.1.3
+version: 0.1.4
 appVersion: "v0.25.1"
 type: application
 maintainers:

--- a/charts/butane-oracle/templates/deployment.yaml
+++ b/charts/butane-oracle/templates/deployment.yaml
@@ -66,29 +66,20 @@ spec:
           timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
           failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
         volumeMounts:
-        {{- if .Values.config.enabled }}
         - name: config
           mountPath: /data
           readOnly: true
-        {{- end }}
-        {{- if and .Values.secrets.fxrates.enabled .Values.secrets.fxrates.name }}
         - name: fxrates
           mountPath: {{ .Values.secrets.fxrates.mountPath }}
           readOnly: true
-        {{- end }}
-        {{- if and .Values.secrets.keys.enabled .Values.secrets.keys.name }}
         - name: keys-app
           mountPath: {{ .Values.secrets.keys.mountPathApp }}
           readOnly: true
-        {{- end }}
         resources: {{ toYaml .Values.resources | nindent 10 }}
       volumes:
-      {{- if .Values.config.enabled }}
       - name: config
         configMap:
           name: {{ include "butane-oracle.fullname" . }}-config
-      {{- end }}
-      {{- if and .Values.secrets.fxrates.enabled .Values.secrets.fxrates.name }}
       - name: fxrates
         secret:
           secretName: {{ .Release.Name }}-fxrates
@@ -97,8 +88,6 @@ spec:
           - key: {{ .key }}
             path: {{ .path | default .key }}
           {{- end }}
-      {{- end }}
-      {{- if and .Values.secrets.keys.enabled .Values.secrets.keys.name }}
       - name: keys-app
         secret:
           secretName: {{ .Release.Name }}-keys
@@ -108,4 +97,3 @@ spec:
           - key: {{ .key }}
             path: {{ .path | default .key }}
           {{- end }}
-      {{- end }}

--- a/charts/butane-oracle/values.yaml
+++ b/charts/butane-oracle/values.yaml
@@ -48,7 +48,6 @@ podMonitor:
 
 # ConfigMap content for config.yaml
 config:
-  enabled: true
   configYaml: |
     logs:
       json: false
@@ -56,16 +55,12 @@ config:
 
 secrets:
   fxrates:
-    # If enabled it creates a secret for fxrates api key
-    enabled: true
     # Data for the secret
     data:
     - key: "fxrates-api.txt"
       value: "FXRATESAPI_API_KEY=123123123"
     mountPath: /data/butane
   keys:
-    # If enabled it creates a secret for butane keys
-    enabled: true
     mountPathApp: /app/keys
     defaultMode: 0755
     # Data for the secret


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make required config and secrets unconditional in the butane-oracle Helm chart to prevent missing volumes/mounts and failing pods. Bumps chart version to 0.1.4.

- **Bug Fixes**
  - Always mount config, fxrates, and keys volumes (remove conditional checks).
  - Remove `enabled` flags from `values.yaml` for config and secrets.

- **Migration**
  - Ensure `fxrates` and `keys` secrets exist and paths match the chart defaults.
  - If you previously disabled these via values, they are now required for deployment.

<sup>Written for commit 4f55a1f1c490099ed08b17adfdf910e50d8a44ed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 0.1.4

* **Refactor**
  * Simplified deployment configuration by removing optional provisioning toggles; required resources are now unconditionally provisioned.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->