### PR TITLE
fix(butane-oracle): fix healthcheck and bump version

### DIFF
--- a/charts/butane-oracle/Chart.yaml
+++ b/charts/butane-oracle/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: butane-oracle
 description: Helm chart for SundaeSwap butane-oracle
-version: 0.1.4
-appVersion: "v0.25.1"
+version: 0.1.5
+appVersion: "v0.25.4"
 type: application
 maintainers:
   - name: aurora

--- a/charts/butane-oracle/templates/deployment.yaml
+++ b/charts/butane-oracle/templates/deployment.yaml
@@ -49,22 +49,8 @@ spec:
           containerPort: {{ .Values.ports.p2p }}
         - name: health
           containerPort: {{ .Values.ports.health }}
-        readinessProbe:
-          httpGet:
-            path: {{ .Values.probes.readiness.path }}
-            port: health
-          initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
-          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
-          failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
-        livenessProbe:
-          httpGet:
-            path: {{ .Values.probes.liveness.path }}
-            port: health
-          initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
-          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
-          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+        readinessProbe: {{ toYaml .Values.probes.readiness | nindent 10 }}
+        livenessProbe: {{ toYaml .Values.probes.liveness | nindent 10 }}
         volumeMounts:
         - name: config
           mountPath: /data

--- a/charts/butane-oracle/values.yaml
+++ b/charts/butane-oracle/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 image:
   repository: "sundaeswap/butane-oracle"
-  tag: "v0.25.1"
+  tag: "v0.25.4"
   pullPolicy: IfNotPresent
 
 command: ["./oracles", "-c", "/data/config.yaml"]
@@ -97,13 +97,15 @@ tolerations: []
 
 probes:
   liveness:
-    path: /health
+    tcpSocket:
+      port: health
     initialDelaySeconds: 10
     periodSeconds: 10
     timeoutSeconds: 10
     failureThreshold: 3
   readiness:
-    path: /health
+    tcpSocket:
+      port: health
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 10


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix health probes by switching to TCP on the health port and render probe config from values to stop failing healthchecks. Bumped chart to 0.1.5 and appVersion to v0.25.4.

- **Bug Fixes**
  - Use tcpSocket on the health port for liveness/readiness probes.
  - Render probes via values (toYaml) in the deployment to remove hardcoded HTTP settings.

- **Dependencies**
  - Chart version: 0.1.5.
  - appVersion: v0.25.4.
  - Image tag: v0.25.4.

<sup>Written for commit a075b5c4d7f69a5db7b0ee37aec50e19ea5430a5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated chart version to 0.1.5 and application image version to v0.25.4.

* **Refactor**
  * Health checks switched from HTTP path-based probes to TCP socket checks for readiness and liveness.
  * Probes are now driven by chart configuration, making health checks more configurable without changing deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->