### PR TITLE
fix(kupo): prevent PID leak in Kupo readiness probe

### DIFF
--- a/charts/kupo/Chart.yaml
+++ b/charts/kupo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kupo
 description: "A Helm chart for deploying Kupo - fast, lightweight & configurable chain-index for Cardano"
-version: 0.0.3
+version: 0.0.4
 appVersion: "2.11.0"
 
 sources:

--- a/charts/kupo/templates/statefulset.yaml
+++ b/charts/kupo/templates/statefulset.yaml
@@ -121,7 +121,7 @@ spec:
                 - -c
                 - |
                   URL='http://localhost:1442/health';
-                  METRICS=$(wget -qO- --header="Accept: text/plain" $URL);
+                  METRICS=$(timeout 20 wget -qO- --header="Accept: text/plain" $URL);
                   NODE_TIP=$(echo "$METRICS" | grep 'kupo_most_recent_node_tip' | awk '{print $NF}' | tr -d '"');
                   CHECKPOINT=$(echo "$METRICS" | grep 'kupo_most_recent_checkpoint' | awk '{print $NF}' | tr -d '"');
                   if [ -z "$NODE_TIP" ] || [ -z "$CHECKPOINT" ]; then
@@ -138,7 +138,7 @@ spec:
                     exit 1;
                   fi
             initialDelaySeconds: 5
-            timeoutSeconds: 1
+            timeoutSeconds: 25
             periodSeconds: 30
             successThreshold: 1
             failureThreshold: 3

--- a/charts/kupo/values.yaml
+++ b/charts/kupo/values.yaml
@@ -20,10 +20,10 @@ connectionMethod:
         repository: "alpine/socat"
         tag: "latest"
         pullPolicy: IfNotPresent
-      nodeHost: ""  # "cardano-node.default.svc.cluster.local"
-      nodePort: ""  # "30000"
+      nodeHost: "cardano-node.default.svc.cluster.local"
+      nodePort: "3001"
     nodeSocket:
-      path: ""  # "/ipc/node.socket"
+      path: "/ipc/node.socket"
     configFetch:
       enabled: true
       image:
@@ -31,9 +31,9 @@ connectionMethod:
         tag: "20250514-1"
         pullPolicy: IfNotPresent
       # Network to fetch configs for
-      network: ""  # mainnet, preview, preprod, etc.
+      network: "mainnet"  # mainnet, preview, preprod, etc.
       # Directory where configs will be copied
-      targetDir: ""  # /opt/cardano
+      targetDir: "/opt/cardano"
     # Specify path to cardano config if not using configFetch
     nodeConfig:
       enabled: false
@@ -58,7 +58,7 @@ kupo:
   logLevel: "Info"
   storage:
     inMemory: false
-    workDir: ""  # "/db/kupo-preview"
+    workDir: "/db"
   server:
     host: "0.0.0.0"
     port: 1442


### PR DESCRIPTION
- Add 20s timeout to wget command to avoid hanging processes
- Increase readiness probe timeoutSeconds to 25s for reliability (period > timeout).





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent PID leaks in the Kupo readiness probe by timing out stuck wget calls and tuning probe timeouts for reliability.

- **Bug Fixes**
  - Wrap wget in a 20s timeout to avoid hanging processes.
  - Increase readinessProbe timeoutSeconds to 25 to keep period > timeout.
  - Update chart to 0.0.4 and set sane values.yaml defaults (node host/port, socket path, config fetch network/dir, storage workDir).

<sup>Written for commit 26e53d76087ca21b01ddc3b340c65f4334bec1f4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Chart version bumped to 0.0.4.
  * Helm chart defaults updated to concrete runtime settings: node host, node port, socket path, network, target directory, and work directory.

* **Bug Fixes**
  * Readiness probe tuning: increased metrics fetch timeout and overall probe timeout to better handle slower metric retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->