### PR TITLE
feat(kupo): Update chart with readiness gate

### DIFF
--- a/charts/kupo/Chart.yaml
+++ b/charts/kupo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kupo
 description: "A Helm chart for deploying Kupo - fast, lightweight & configurable chain-index for Cardano"
-version: 0.0.4
+version: 0.0.5
 appVersion: "2.11.0"
 
 sources:

--- a/charts/kupo/templates/_helpers.tpl
+++ b/charts/kupo/templates/_helpers.tpl
@@ -54,9 +54,5 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "kupo.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "kupo.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{- printf "%s-sa" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/charts/kupo/templates/role.yaml
+++ b/charts/kupo/templates/role.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kupo.serviceAccountName" . }}
+  labels:
+    {{- include "kupo.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods/status"]
+  verbs: ["patch"]

--- a/charts/kupo/templates/rolebinding.yaml
+++ b/charts/kupo/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kupo.serviceAccountName" . }}
+  labels:
+    {{- include "kupo.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kupo.serviceAccountName" . }}
+roleRef:
+  kind: Role
+  name: {{ include "kupo.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kupo/templates/serviceaccount.yaml
+++ b/charts/kupo/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceAccount.create -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -13,4 +12,3 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}

--- a/charts/kupo/templates/statefulset.yaml
+++ b/charts/kupo/templates/statefulset.yaml
@@ -27,9 +27,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ .Values.serviceAccount.name | default (include "kupo.fullname" .) }}
-      {{- end }}
+      readinessGates:
+        - conditionType: KupoReady
+      serviceAccountName: {{ include "kupo.serviceAccountName" . }}
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -114,34 +114,6 @@ spec:
             {{- end }}
             - name: db
               mountPath: {{ .Values.kupo.storage.workDir }}
-          readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - |
-                  URL='http://localhost:1442/health';
-                  METRICS=$(timeout 20 wget -qO- --header="Accept: text/plain" $URL);
-                  NODE_TIP=$(echo "$METRICS" | grep 'kupo_most_recent_node_tip' | awk '{print $NF}' | tr -d '"');
-                  CHECKPOINT=$(echo "$METRICS" | grep 'kupo_most_recent_checkpoint' | awk '{print $NF}' | tr -d '"');
-                  if [ -z "$NODE_TIP" ] || [ -z "$CHECKPOINT" ]; then
-                    echo 'Error: NODE_TIP or CHECKPOINT is null.';
-                    exit 1;
-                  fi;
-                  if [ "$NODE_TIP" = '0' ] || [ "$CHECKPOINT" = '0' ]; then
-                    echo 'Error: NODE_TIP or CHECKPOINT is 0.';
-                    exit 1;
-                  fi;
-                  if [ "$NODE_TIP" = "$CHECKPOINT" ]; then
-                    exit 0;
-                  else
-                    exit 1;
-                  fi
-            initialDelaySeconds: 5
-            timeoutSeconds: 25
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 3
         {{- if eq .Values.connectionMethod.node.enabled true }}
         - name: socat
           image: "{{ .Values.connectionMethod.node.socat.image.repository }}:{{ .Values.connectionMethod.node.socat.image.tag }}"
@@ -154,6 +126,40 @@ spec:
             - name: cardanoipc
               mountPath: /ipc
         {{- end }}
+        - name: readiness-check
+          image: "{{ .Values.readinessCheck.image.repository }}:{{ .Values.readinessCheck.image.tag }}"
+          imagePullPolicy: {{ .Values.readinessCheck.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              URL='http://localhost:{{ .Values.kupo.server.port }}/health'
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+              POD_NAME=$HOSTNAME
+              CA_CERT='/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+              LAST_READY='False'
+              while true; do
+                READY='False'
+                if METRICS=$(curl -sf --max-time {{ .Values.readinessCheck.maxTime }} --header "Accept: text/plain" "$URL"); then
+                  NODE_TIP=$(echo "$METRICS" | grep 'kupo_most_recent_node_tip' | awk '{print $NF}' | tr -d '"')
+                  CHECKPOINT=$(echo "$METRICS" | grep 'kupo_most_recent_checkpoint' | awk '{print $NF}' | tr -d '"')
+                  if [ -n "$NODE_TIP" ] && [ -n "$CHECKPOINT" ] && [ "$NODE_TIP" != '0' ] && [ "$CHECKPOINT" != '0' ] && [ "$NODE_TIP" = "$CHECKPOINT" ]; then
+                    READY='True'
+                  fi
+                fi
+                if [ "$READY" != "$LAST_READY" ]; then
+                  echo "Kupo readiness changed: $READY"
+                  LAST_READY="$READY"
+                  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                  PATCH_BODY=$(printf '{"status":{"conditions":[{"type":"KupoReady","status":"%s","lastTransitionTime":"%s"}]}}' "$READY" "$TIMESTAMP")
+                  curl -s --cacert "$CA_CERT" -X PATCH \
+                    -H "Authorization: Bearer $TOKEN" \
+                    -H "Content-Type: application/merge-patch+json" \
+                    https://kubernetes.default.svc/api/v1/namespaces/$NAMESPACE/pods/$POD_NAME/status \
+                    -d "$PATCH_BODY" || true
+                fi
+                sleep {{ .Values.readinessCheck.sleepInterval }}
+              done
       volumes:
         {{- if eq .Values.connectionMethod.node.enabled true }}
         - name: cardanoipc

--- a/charts/kupo/values.yaml
+++ b/charts/kupo/values.yaml
@@ -6,6 +6,15 @@ image:
   tag: "v2.11.0"
   pullPolicy: IfNotPresent
 
+# Readiness gate / liveness probe settings
+readinessCheck:
+  image:
+    repository: curlimages/curl
+    tag: latest
+    pullPolicy: IfNotPresent
+  maxTime: 20
+  sleepInterval: 30
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -28,7 +37,7 @@ connectionMethod:
       enabled: true
       image:
         repository: ghcr.io/blinklabs-io/cardano-configs
-        tag: "20250514-1"
+        tag: "20251128-1"
         pullPolicy: IfNotPresent
       # Network to fetch configs for
       network: "mainnet"  # mainnet, preview, preprod, etc.
@@ -81,12 +90,8 @@ kupo:
       annotations: {}
 
 serviceAccount:
-  create: true
   annotations: {}
   labels: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: "kupo-sa"
 
 resources: {}
 #  limits:


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a readiness gate for Kupo using a sidecar that sets a custom Pod condition (KupoReady), replacing the old readiness probe for more accurate startup signaling. Also standardizes the service account and updates the chart and config image versions.

- **New Features**
  - Readiness gate via a readiness-check sidecar that patches Pod status with KupoReady based on Kupo metrics.
  - RBAC added (Role + RoleBinding) to allow patching pods/status.
  - Service account is always created and named "<release>-sa"; StatefulSet now uses readinessGates and this service account.
  - New values under readinessCheck for image and timing.

- **Migration**
  - Remove serviceAccount.create and serviceAccount.name from values; the chart now creates "<release>-sa" automatically.
  - The container readinessProbe is removed; readiness is driven by the KupoReady gate. Adjust readinessCheck values if needed.

<sup>Written for commit 73f615aa3ce55a6454b5ea2de29a48fa796f31c2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RBAC resources for finer permissions.
  * Introduced an HTTP-based readiness check sidecar and readiness gate.

* **Changes**
  * Service account is now always created and its name follows a standardized pattern.
  * Added configurable readinessCheck settings and updated a container image tag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->