### PR TITLE
refactor(dolos): refactor Dolos chart: add socat socket sidecar

### DIFF
--- a/charts/dolos/Chart.yaml
+++ b/charts/dolos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dolos
 description: Dolos server
-version: 0.2.11
+version: 0.3.0
 appVersion: "0.32.0"
 
 sources:

--- a/charts/dolos/templates/_helpers.tpl
+++ b/charts/dolos/templates/_helpers.tpl
@@ -44,7 +44,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "dolos.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "dolos.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-cardano_network: {{ .Values.dolos.network }}
+app.kubernetes.io/name: {{ include "dolos.name" . }}
+cardano_network: {{ .Values.network }}
 {{- end }}

--- a/charts/dolos/templates/configmap.yaml
+++ b/charts/dolos/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "dolos.fullname" . }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 data:
   dolos.toml: |
@@ -30,9 +30,9 @@ data:
     {{- end }}
 
     [storage]
-    version = "v1"
+    version = "{{ .Values.configmap.storage.version }}"
     path = "/var/data/{{ .Values.network }}/db"
-    wal_size = 1000
+    wal_size = {{ .Values.configmap.storage.wal_size }}
 
     [genesis]
     byron_path = "/etc/genesis/{{ .Values.network }}/byron.json"
@@ -41,10 +41,10 @@ data:
     conway_path = "/etc/genesis/{{ .Values.network }}/conway.json"
 
     [sync]
-    pull_batch_size = 100
+    pull_batch_size = {{ .Values.configmap.sync.pull_batch_size }}
 
     [submit]
-    prune_height = 200
+    prune_height = {{ .Values.configmap.submit.prune_height }}
 
     [mithril]
     aggregator = "https://aggregator.release-{{ .Values.network }}.api.mithril.network/aggregator"
@@ -72,9 +72,9 @@ data:
     listen_address = "[::]:{{ .Values.ports.minibf }}"
 
     [logging]
-    max_level = "debug"
-    include_tokio = false
-    include_pallas = false
-    include_grpc = true
-    include_trp = false
-    include_minibf = false
+    max_level = "{{ .Values.configmap.logging.max_level }}"
+    include_tokio = {{ .Values.configmap.logging.include_tokio }}
+    include_pallas = {{ .Values.configmap.logging.include_pallas }}
+    include_grpc = {{ .Values.configmap.logging.include_grpc }}
+    include_trp = {{ .Values.configmap.logging.include_trp }}
+    include_minibf = {{ .Values.configmap.logging.include_minibf }}

--- a/charts/dolos/templates/headless-service.yaml
+++ b/charts/dolos/templates/headless-service.yaml
@@ -1,16 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dolos.fullname" . }}
+  name: {{ .Values.service.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "dolos.fullname" . }}
+    app.kubernetes.io/name: {{ include "dolos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    cardano.demeter.run/network: {{ .Values.network }}
 spec:
   clusterIP: None  # Headless service
-  selector:
-    app.kubernetes.io/name: {{ include "dolos.fullname" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "dolos.selectorLabels" . | nindent 4 }}
   ports:
     - name: grpc
       port: {{ .Values.service.ports.grpc }}

--- a/charts/dolos/templates/sts.yaml
+++ b/charts/dolos/templates/sts.yaml
@@ -1,21 +1,17 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "dolos.fullname" . }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "dolos.fullname" . }}
+    app.kubernetes.io/name: {{ include "dolos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: dolos
-    app.kubernetes.io/part-of: dolos
     cardano.demeter.run/network: {{ .Values.network }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  serviceName: {{ include "dolos.fullname" . }}
+  serviceName: {{ .Values.service.name | default .Release.Name }}
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "dolos.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "dolos.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -23,10 +19,10 @@ spec:
         {{- if .Values.podAnnotations }}
           {{ toYaml .Values.podAnnotations | nindent 4 }}
         {{- end }}
-      labels:
-        app.kubernetes.io/name: {{ include "dolos.fullname" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        cardano.demeter.run/network: {{ .Values.network }}
+      labels: {{- include "dolos.selectorLabels" . | nindent 8 -}}
+        {{- if .Values.podLabels }}
+          {{- toYaml .Values.podLabels | nindent 8 -}}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 180
       {{- if .Values.tolerations }}
@@ -38,7 +34,9 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "dolos.fullname" . }}
+            name: {{ .Release.Name }}
+        - name: dolos-ipc
+          emptyDir: {}
       initContainers:
         - name: init
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -57,6 +55,8 @@ spec:
               mountPath: /etc/config
             - name: data
               mountPath: /var/data
+            - name: dolos-ipc
+              mountPath: /ipc
       containers:
         - name: dolos
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -72,16 +72,33 @@ spec:
               mountPath: /etc/config
             - name: data
               mountPath: /var/data
+            - name: dolos-ipc
+              mountPath: /ipc
           ports:
             - name: grpc
               containerPort: {{ .Values.ports.grpc }}
               protocol: TCP
-            - name: ouroboros
-              containerPort: {{ .Values.ports.ouroboros }}
-              protocol: TCP
             - name: minibf
               containerPort: {{ .Values.ports.minibf }}
               protocol: TCP
+        - name: socat-ntc
+          image: "{{ .Values.socat.image.repository }}:{{ .Values.socat.image.tag }}"
+          imagePullPolicy: {{ .Values.socat.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: PORT
+              value: "{{ .Values.ports.ouroboros }}"
+          command:
+            - sh
+            - -c
+            - socat TCP-LISTEN:${PORT},fork UNIX-CLIENT:/ipc/dolos.socket,ignoreeof
+          ports:
+            - name: socat-ntc
+              containerPort: {{ .Values.ports.ouroboros }}
+          resources:
+            {{- toYaml .Values.socat.resources | nindent 12 }}
+          volumeMounts:
+            - name: dolos-ipc
+              mountPath: /ipc
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/dolos/values.yaml
+++ b/charts/dolos/values.yaml
@@ -11,6 +11,8 @@ image:
   pullPolicy: IfNotPresent
 
 podAnnotations: {}
+podLabels: {}
+
 resources:
   limits:
     cpu: "1"
@@ -25,6 +27,8 @@ ports:
   minibf: 3001
 
 service:
+  # Optional custom service name. If not set, release name will be used.
+  name: ""
   ports:
     grpc: 15051
     ouroboros: 13013
@@ -50,3 +54,28 @@ affinity: {}
 #               values:
 #                 - dolos
 #         topologyKey: "kubernetes.io/hostname"
+
+# Socat sidecar configuration
+socat:
+  image:
+    repository: "alpine/socat"
+    tag: "1.8.0.3"
+    pullPolicy: IfNotPresent
+  resources: {}
+
+# Dolos specific configuration values
+configmap:
+  logging:
+    max_level: "debug"
+    include_tokio: false
+    include_pallas: false
+    include_grpc: true
+    include_trp: false
+    include_minibf: false
+  storage:
+    version: "v1"
+    wal_size: 1000
+  submit:
+    prune_height: 200
+  sync:
+    pull_batch_size: 100


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a socat sidecar to proxy the Ouroboros TCP port to a UNIX socket, and makes Dolos ConfigMap settings configurable via values. Also standardizes resource names and selectors to be simpler and consistent.

- **New Features**
  - Added socat sidecar that forwards TCP on ports.ouroboros to /ipc/dolos.socket.
  - Introduced dolos-ipc emptyDir volume shared by containers.
  - Made logging, storage, submit, and sync settings configurable under values.configmap.
  - Added optional podLabels and service.name override.

- **Refactors**
  - Renamed ConfigMap, Service, and StatefulSet to use Release.Name; unified selectors via dolos.selectorLabels.
  - Switched cardano_network label to .Values.network and added cardano.demeter.run/network label on Service.
  - Service selector now uses shared labels; consistent app.kubernetes.io/name.
  - Ouroboros port is now exposed by the sidecar (removed from the main Dolos container).

<sup>Written for commit 71a93ce542c9b4fb2dde66f4628ff26c99018976. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Socat sidecar for IPC-to-TCP bridging
  * Exposed additional service ports
  * Added pod label support

* **Changes**
  * Made logging, storage, and sync settings configurable
  * Converted several hardcoded values to templated/configurable entries
  * Improved network-related labeling and service naming
* **Other**
  * Chart version bumped to 0.3.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->