### PR TITLE
feat(dingo): enhance chart using mithril-client

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo"
-version: 0.0.23
+version: 0.0.24
 appVersion: 0.18.0
 
 sources:

--- a/charts/dingo/templates/service-account.yaml
+++ b/charts/dingo/templates/service-account.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Release.Name }}
   {{- if .Values.serviceAccount.annotations }}
   annotations: {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}

--- a/charts/dingo/templates/statefulset.yaml
+++ b/charts/dingo/templates/statefulset.yaml
@@ -17,9 +17,146 @@ spec:
         app.kubernetes.io/name: {{ include "dingo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Release.Name }}
       {{- if .Values.tolerations }}
       tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.mithril.enabled }}
+      initContainers:
+      # Download Cardano snapshot using mithril-client
+      - name: mithril-snapshot
+        image: {{ .Values.mithril.image.repository }}:{{ .Values.mithril.image.tag }}
+        imagePullPolicy: {{ .Values.mithril.image.pullPolicy }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            if [ "$DEBUG_INIT" = "true" ]; then
+              echo "DEBUG: Checking mithril data directory..."
+              ls -la /mithril-data/ || true
+              echo "DEBUG: Checking for db subdirectory..."
+              ls -la /mithril-data/db/ || true
+            fi
+
+            # Check if snapshot was successfully downloaded (marker file indicates complete download)
+            if [ -f "/mithril-data/.download-complete" ] && [ "$FORCE_REDOWNLOAD" != "true" ]; then
+              echo "Mithril snapshot already exists at /mithril-data/db/ (verified by marker file)"
+              exit 0
+            fi
+
+            # Remove existing data if force redownload is enabled
+            if [ "$FORCE_REDOWNLOAD" = "true" ]; then
+              echo "Force redownload enabled, removing existing mithril data..."
+              rm -rf /mithril-data/*
+            fi
+
+            echo "Starting mithril snapshot download..."
+            if mithril-client cardano-db download {{ .Values.mithril.snapshotDigest | default "latest" }} \
+              --download-dir /mithril-data \
+              --json; then
+              # Create marker file to indicate successful download
+              touch /mithril-data/.download-complete
+              echo "Mithril snapshot download complete"
+            else
+              echo "ERROR: Mithril snapshot download failed"
+              exit 1
+            fi
+        env:
+          - name: AGGREGATOR_ENDPOINT
+            value: {{ .Values.mithril.aggregatorEndpoint | quote }}
+          - name: GENESIS_VERIFICATION_KEY
+            value: {{ .Values.mithril.genesisVerificationKey | quote }}
+          - name: FORCE_REDOWNLOAD
+            value: {{ .Values.mithril.forceRedownload | quote }}
+          - name: DEBUG_INIT
+            value: {{ .Values.mithril.debugInit | quote }}
+        volumeMounts:
+          - name: dingo-data
+            mountPath: /mithril-data
+            subPath: mithril
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 12 }}
+        {{- end }}
+      # Load blocks from immutable DB into Dingo's database
+      - name: dingo-load
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            if [ "$DEBUG_INIT" = "true" ]; then
+              echo "DEBUG: Listing CARDANO_DATABASE_PATH..."
+              ls -la {{ .Values.environment.CARDANO_DATABASE_PATH }} || true
+              echo "DEBUG: Listing mithril data directory..."
+              ls -la /mithril-data/ || true
+              echo "DEBUG: Listing mithril db subdirectory..."
+              ls -la /mithril-data/db/ || true
+              # echo "DEBUG: Checking for immutable directory..."
+              # ls -la /mithril-data/db/immutable/ || true
+            fi
+
+            # Check if force reload is enabled
+            if [ "$FORCE_RELOAD" = "true" ]; then
+              echo "Force reload enabled, removing existing Dingo database..."
+              rm -rf {{ .Values.environment.CARDANO_DATABASE_PATH }}/blob/* \
+                     {{ .Values.environment.CARDANO_DATABASE_PATH }}/db/* \
+                     {{ .Values.environment.CARDANO_DATABASE_PATH }}/metadata.sqlite* 2>/dev/null || true
+              rmdir {{ .Values.environment.CARDANO_DATABASE_PATH }}/blob \
+                    {{ .Values.environment.CARDANO_DATABASE_PATH }}/db 2>/dev/null || true
+            fi
+
+            # Check if Dingo database already initialized (dingo creates blob/, db/, and metadata.sqlite)
+            if [ -f "{{ .Values.environment.CARDANO_DATABASE_PATH }}/metadata.sqlite" ]; then
+              echo "Dingo database already initialized, skipping load"
+              exit 0
+            fi
+
+            # Check if immutable data exists (mithril downloads to db/ subdirectory)
+            if [ ! -d "/mithril-data/db/immutable" ] || [ "$(ls -A /mithril-data/db/immutable 2>/dev/null | wc -l)" -eq 0 ]; then
+              echo "ERROR: No immutable data found at /mithril-data/db/immutable"
+              exit 1
+            fi
+
+            echo "Loading immutable data into Dingo database..."
+            cd {{ .Values.environment.CARDANO_DATABASE_PATH }}
+            dingo load /mithril-data/db/immutable
+            echo "Dingo load complete"
+
+            # Cleanup mithril data to reclaim storage space (if configured)
+            if [ "$CLEANUP_AFTER_LOAD" = "true" ]; then
+              echo "Cleaning up mithril snapshot data to reclaim storage..."
+              rm -rf /mithril-data/*
+              echo "Cleanup complete - reclaimed storage space."
+            else
+              echo "Keeping mithril snapshot data for potential reloads"
+            fi
+        env:
+          {{- range $key, $value := .Values.environment }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          - name: FORCE_RELOAD
+            value: {{ .Values.mithril.forceReload | quote }}
+          - name: CLEANUP_AFTER_LOAD
+            value: {{ .Values.mithril.cleanupAfterLoad | quote }}
+          - name: DEBUG_INIT
+            value: {{ .Values.mithril.debugInit | quote }}
+        volumeMounts:
+          - name: dingo-data
+            mountPath: {{ .Values.environment.CARDANO_DATABASE_PATH }}
+          - name: dingo-data
+            mountPath: /mithril-data
+            subPath: mithril
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 12 }}
+        {{- end }}
       {{- end }}
       containers:
       - name: dingo
@@ -57,4 +194,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size }}
+        {{- if .Values.persistence.storageClass }}
         storageClassName: {{ .Values.persistence.storageClass }}
+        {{- end }}

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -3,8 +3,47 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.18.0"
+  tag: "0.19.0"
   pullPolicy: IfNotPresent
+
+mithril:
+  enabled: true
+  image:
+    repository: ghcr.io/blinklabs-io/mithril-client
+    tag: "0.12.33"
+    pullPolicy: IfNotPresent
+  # Mithril aggregator URL
+  # All network configurations (aggregator endpoints, genesis keys, etc.) are documented at:
+  # https://github.com/input-output-hk/mithril/blob/main/networks.json
+  #
+  # Aggregator endpoints:
+  # Mainnet: https://aggregator.release-mainnet.api.mithril.network/aggregator
+  # Preprod: https://aggregator.release-preprod.api.mithril.network/aggregator
+  # Preview (pre-release): https://aggregator.pre-release-preview.api.mithril.network/aggregator
+  # Preview (testing): https://aggregator.testing-preview.api.mithril.network/aggregator
+  aggregatorEndpoint: "https://aggregator.pre-release-preview.api.mithril.network/aggregator"
+  # Genesis verification key for the network
+  # Fetch from networks.json genesis.verification-key.url for each network
+  # Mainnet: curl -sL https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/genesis.vkey
+  # Preprod: curl -sL https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey
+  # Preview: curl -sL https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey
+  genesisVerificationKey: "5b3132372c37332c3132342c3136312c362c3133372c3133312c3231332c3230372c3131372c3139382c38352c3137362c3139392c3136322c3234312c36382c3132332c3131392c3134352c31332c3233322c3234332c34392c3232392c322c3234392c3230352c3230352c33392c3233352c34345d"
+  # Specific snapshot digest to download (leave empty for latest)
+  snapshotDigest: ""
+  # Force re-download of mithril snapshot even if data exists
+  # Useful for updating to a newer snapshot
+  # WARNING: This will delete existing mithril data
+  forceRedownload: false
+  # Force re-load of Dingo database from immutable data even if database exists
+  # Useful for rebuilding database from existing snapshot without re-downloading
+  # WARNING: This will delete existing Dingo database
+  forceReload: false
+  # Cleanup mithril snapshot data after loading to reclaim storage space
+  # WARNING: If forceReload is true and this is true, subsequent restarts won't be able to reload
+  # Recommended: false if forceReload is true, true otherwise to save storage
+  cleanupAfterLoad: false
+  # Enable debug logging in init containers (shows directory listings, etc.)
+  debugInit: false
 
 environment:
   CARDANO_NETWORK: "preview"
@@ -36,8 +75,8 @@ tolerations: []
 
 persistence:
   accessMode: ReadWriteOnce
-  size: 40Gi
-  storageClass: ""
+  size: 60Gi
+  # storageClass: "hyperdisk-balanced"
 
 service:
   annotations: {}
@@ -49,5 +88,4 @@ service:
     metrics: 12789
 
 serviceAccount:
-  name: dingo-sa
   annotations: {}


### PR DESCRIPTION
Closes #227 

Tests
Cardano - preview

Logs from `mithril-snapshot` initContainer
```
{"timestamp": "2025-12-16T00:58:15.623693837+00:00", "step_num": 7, "total_steps": 7, "message": "Verifying the cardano db signature…"}
{"db_directory":"/mithril-data/db","timestamp":"2025-12-16T00:58:15.623751254+00:00"}
Mithril snapshot download complete
```

Logs from `dingo-load` initContainer
```
{"time":"2025-12-16T17:37:38.605471883Z","level":"INFO","msg":"chain extended, new tip: 8d00a30a3569a7c6b8ca63e5d673a3bdbcf7e5653c39b5d097eb4bc7ae5854b9 at slot 99174204","component":"ledger"}
{"time":"2025-12-16T17:37:39.6923198Z","level":"INFO","msg":"finished processing 0 blocks from immutable DB"}
Dingo load complete
Cleaning up mithril snapshot data to reclaim storage...
Cleanup complete - reclaimed storage space.
```

Logs from `dingo` container
```
854b55e1103405abc4102cc387b33ca4b22129d236a3fcaa at slot 99252721","component":"ledger"}
{"time":"2025-12-16T18:12:13.511914635Z","level":"INFO","msg":"chain extended, new tip: e7d79bacd549fed9c5b3bc1b317e1dcee65e0debe0729a0fa8cfeff4bd866fcd at slot 99252733","component":"ledger"}
```

























<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates mithril-client into the Dingo Helm chart to download a Cardano snapshot and pre-load immutable blocks before the app starts, reducing initial sync time. Also simplifies ServiceAccount naming and makes storage and Mithril settings configurable.

- **New Features**
  - Init containers: mithril-snapshot and dingo-load.
  - Config in values.yaml for aggregatorEndpoint, genesisVerificationKey, snapshotDigest, forceRedownload/forceReload, cleanupAfterLoad, debugInit.
  - Skips download/load when data already exists; optional cleanup to reclaim storage.

- **Refactors**
  - ServiceAccount now uses Release.Name.
  - PVC default size increased to 60Gi; storageClass rendered only when set.
  - Standardized env and mounts using CARDANO_DATABASE_PATH.

<sup>Written for commit c55297a693041f3ef129008ab036ca4591709797. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



























<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Mithril initialization workflow (precheck, download, load) with configurable image, aggregator endpoint, verification key, snapshot, and force/cleanup/debug flags.

* **Chores**
  * Chart version bumped to 0.0.24; container image tag updated to 0.19.0.
  * Default persistent storage increased from 40Gi to 60Gi; optional storageClass placeholder added.
  * Service account naming now derives from the release name.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->