### PR TITLE
fix(cardano-node): add subpath to block producer volume mount

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.6.4
+version: 0.6.5
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -78,8 +78,11 @@ spec:
           subPath: topology.json
 {{- end }}
 {{- if .Values.blockProducer.enabled }}
-        - mountPath: /opt/cardano/config/keys
-          name: block-producer-keys
+{{- range .Values.blockProducer.keys }}
+        - name: block-producer-keys
+          mountPath: /opt/cardano/config/keys/{{ .name }}
+          subPath: {{ .name }}
+{{- end }}
 {{- end }}
       - name: socat-ntc
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the cardano-node StatefulSet to mount block producer keys by subPath, placing each key at /opt/cardano/config/keys/<name> instead of mounting the entire keys directory. This supports multiple keys and prevents overwriting.

- **Dependencies**
  - Chart version bumped to 0.6.5.

<sup>Written for commit a0a7c42a7f50ce513a132a7986141a46fb3595cb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block-producer keys can now be mounted individually to separate paths, enabling multiple key exposures.

* **Chores**
  * Release version bumped to 0.6.5.
  * Maintainer contact entries added/expanded in chart metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->