### PR TITLE
fix(cardano-node): move BP keys mount to /keys

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.6.5
+version: 0.6.6
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -52,11 +52,11 @@ spec:
         - name: CARDANO_BLOCK_PRODUCER
           value: "true"
         - name: CARDANO_SHELLEY_KES_KEY
-          value: "/opt/cardano/config/keys/kes.skey"
+          value: "/keys/kes.skey"
         - name: CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE
-          value: "/opt/cardano/config/keys/node.cert"
+          value: "/keys/node.cert"
         - name: CARDANO_SHELLEY_VRF_KEY
-          value: "/opt/cardano/config/keys/vrf.skey"
+          value: "/keys/vrf.skey"
 {{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -80,7 +80,7 @@ spec:
 {{- if .Values.blockProducer.enabled }}
 {{- range .Values.blockProducer.keys }}
         - name: block-producer-keys
-          mountPath: /opt/cardano/config/keys/{{ .name }}
+          mountPath: /keys/{{ .name }}
           subPath: {{ .name }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardize block producer key mount and env paths to /keys to fix key resolution in cardano-node. Chart version updated to 0.6.6.

<sup>Written for commit affc61d1a756232ec9e8950a3cc6ba7f3735497f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm Chart to version 0.6.6 with deployment configuration improvements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->