### PR TITLE
fix(cardano-node): restoring prior key mount behavior

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.6.5
+version: 0.6.6
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -78,12 +78,10 @@ spec:
           subPath: topology.json
 {{- end }}
 {{- if .Values.blockProducer.enabled }}
-{{- range .Values.blockProducer.keys }}
         - name: block-producer-keys
-          mountPath: /opt/cardano/config/keys/{{ .name }}
-          subPath: {{ .name }}
+          mountPath: /opt/cardano/config/keys
 {{- end }}
-{{- end }}
+
       - name: socat-ntc
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the previous block producer key mounting so the full keys volume is mounted (no per-file subPath), ensuring all keys are available at runtime. Bumps the Helm chart to 0.6.6.

- **Bug Fixes**
  - Mount the block-producer-keys volume once instead of per key to prevent missing key files.

<sup>Written for commit 75f9b3c8bdc00ce5c31fe0dc1174c5036db12132. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped chart version to 0.6.6.

* **Bug Fixes**
  * Simplified block-producer key handling: when block producer is enabled, keys are exposed via a single mount path instead of per-key mounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->