### PR TITLE
chore: dingo 0.20.0

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo"
-version: 0.0.24
-appVersion: 0.18.0
+version: 0.0.25
+appVersion: 0.20.0
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.19.0"
+  tag: "0.20.0"
   pullPolicy: IfNotPresent
 
 mithril:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Dingo Helm chart to release 0.20.0. Bumps chart version to 0.0.25 and sets image tag/appVersion to 0.20.0 so deployments use the latest image.

<sup>Written for commit 4bb24bc408e61279ccad386b2e0d8e7d4238bb60. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated to release version 0.0.25
  * Container image updated to version 0.20.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->