### PR TITLE
feat(ext-kupo-operator): Remove unsupported env

### DIFF
--- a/charts/ext-kupo-operator/Chart.yaml
+++ b/charts/ext-kupo-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: ext-kupo-operator
 description: Extention Kupo operator
-version: 0.0.1
-appVersion: "0.0.1"
+version: 0.0.2
+appVersion: "0.0.2"
 
 sources:
   - https://github.com/demeter-run/ext-cardano-kupo

--- a/charts/ext-kupo-operator/templates/deployment.yaml
+++ b/charts/ext-kupo-operator/templates/deployment.yaml
@@ -24,8 +24,6 @@ spec:
               value: {{ .Values.prometheusUrl | quote }}
             - name: METRICS_DELAY
               value: {{ .Values.metricsDelay | quote }}
-            - name: DCU_PER_REQUEST
-              value: "mainnet={{ .Values.perRequestDcus.mainnet }},preprod={{ .Values.perRequestDcus.default }},preview={{ .Values.perRequestDcus.default }},sanchonet={{ .Values.perRequestDcus.default }}"
             - name: API_KEY_SALT
               value: {{ .Values.apiKeySalt | quote }}
             - name: DEFAULT_KUPO_VERSION

--- a/charts/ext-kupo-operator/values.yaml
+++ b/charts/ext-kupo-operator/values.yaml
@@ -14,14 +14,6 @@ defaultKupoVersion: "v2"
 dnsZone: "example.com"
 extensionSubdomain: "kupo.example.com"
 
-# DCU per request configuration
-perRequestDcus:
-  mainnet: "10"
-  preprod: "5"
-  preview: "5"
-  sanchonet: "5"
-  default: "5"
-
 resources:
   limits:
     cpu: "100m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unsupported DCU_PER_REQUEST env and related perRequestDcus values from the ext-kupo-operator Helm chart. Bumped chart and appVersion to 0.0.2.

- **Migration**
  - Remove perRequestDcus from your values.yaml; DCU_PER_REQUEST is no longer used.
  - No replacement is needed.

<sup>Written for commit d946b61c34959626a9cb4bcfbeb274345d2c716b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Helm chart version bumped to 0.0.2
  * Removed environment-specific resource allocation configuration from deployment, streamlining the deployment settings and reducing deployment variables

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->