### PR TITLE
feat(cardano-node): add mithril-snapshot download to initContainer

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.6.6
+version: 0.7.0
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -24,6 +24,129 @@ spec:
 {{- if .Values.affinity }}
       affinity: {{ .Values.affinity | toYaml | nindent 8 }}
 {{- end }}
+{{- if .Values.mithril.enabled }}
+      initContainers:
+      # Download Cardano snapshot using mithril-client
+      - name: mithril-snapshot
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            NETWORK="{{ .Values.cardano_network }}"
+
+            if [ "$DEBUG_INIT" = "true" ]; then
+              echo "DEBUG: Network: ${NETWORK}"
+              echo "DEBUG: Checking data directory..."
+              ls -la /data/ || true
+              echo "DEBUG: Checking for db subdirectory..."
+              ls -la /data/db/ || true
+            fi
+
+            if ! command -v jq >/dev/null 2>&1; then
+              echo "ERROR: jq is required but not found in the image"
+              exit 1
+            fi
+            if ! command -v mithril-client >/dev/null 2>&1; then
+              echo "ERROR: mithril-client is required but not found in the image"
+              exit 1
+            fi
+
+            # Check if database already exists (skip mithril if db exists)
+            if test -e /data/db/protocolMagicId && [ "$FORCE_REDOWNLOAD" != "true" ]; then
+              echo "Database already exists at /data/db/ (protocolMagicId found), skipping mithril download"
+              exit 0
+            fi
+
+            # Remove existing data if force redownload is enabled
+            if [ "$FORCE_REDOWNLOAD" = "true" ]; then
+              echo "Force redownload enabled, removing existing data..."
+              rm -rf /data/db/* 2>/dev/null || true
+            fi
+
+            # Determine aggregator path based on network
+            case ${NETWORK} in
+              mainnet|preprod) __path=release-${NETWORK} ;;
+              preview) __path=pre-release-${NETWORK} ;;
+              *) echo "Mithril not supported on ${NETWORK}... skipping"; exit 0 ;;
+            esac
+
+            if [ "$DEBUG_INIT" = "true" ]; then
+              echo "DEBUG: Checking for config files in /opt/cardano/config/${NETWORK}/"
+              ls -la /opt/cardano/config/${NETWORK}/ || true
+              echo "DEBUG: Contents of genesis.vkey:"
+              cat /opt/cardano/config/${NETWORK}/genesis.vkey || true
+              echo "DEBUG: Contents of ancillary.vkey:"
+              cat /opt/cardano/config/${NETWORK}/ancillary.vkey || true
+            fi
+
+            # Read keys from image config files if they exist, otherwise use values from helm chart
+            if [ -f "/opt/cardano/config/${NETWORK}/genesis.vkey" ] && [ -s "/opt/cardano/config/${NETWORK}/genesis.vkey" ]; then
+              GENESIS_VERIFICATION_KEY=$(cat /opt/cardano/config/${NETWORK}/genesis.vkey)
+              export GENESIS_VERIFICATION_KEY
+            elif [ -n "{{ .Values.mithril.genesisVerificationKey }}" ]; then
+              export GENESIS_VERIFICATION_KEY="{{ .Values.mithril.genesisVerificationKey }}"
+            else
+              echo "ERROR: Genesis verification key not found in image or values.yaml"
+              echo "Please set mithril.genesisVerificationKey in values.yaml"
+              exit 1
+            fi
+
+            if [ -f "/opt/cardano/config/${NETWORK}/ancillary.vkey" ] && [ -s "/opt/cardano/config/${NETWORK}/ancillary.vkey" ]; then
+              ANCILLARY_VERIFICATION_KEY=$(cat /opt/cardano/config/${NETWORK}/ancillary.vkey)
+              export ANCILLARY_VERIFICATION_KEY
+            elif [ -n "{{ .Values.mithril.ancillaryVerificationKey }}" ]; then
+              export ANCILLARY_VERIFICATION_KEY="{{ .Values.mithril.ancillaryVerificationKey }}"
+            else
+              echo "No ancillary verification key found (optional - skipping fast bootstrap)"
+            fi
+
+            export AGGREGATOR_ENDPOINT=https://aggregator.${__path}.api.mithril.network/aggregator
+
+            if [ "$DEBUG_INIT" = "true" ]; then
+              echo "DEBUG: GENESIS_VERIFICATION_KEY=${GENESIS_VERIFICATION_KEY}"
+              echo "DEBUG: ANCILLARY_VERIFICATION_KEY=${ANCILLARY_VERIFICATION_KEY}"
+              echo "DEBUG: AGGREGATOR_ENDPOINT=${AGGREGATOR_ENDPOINT}"
+            fi
+
+            # Get snapshot digest (use configured value or fetch latest)
+            if [ -n "{{ .Values.mithril.snapshotDigest }}" ]; then
+              SNAPSHOT_DIGEST="{{ .Values.mithril.snapshotDigest }}"
+              echo "Using configured snapshot digest: ${SNAPSHOT_DIGEST}"
+            else
+              echo "Fetching latest snapshot digest from ${AGGREGATOR_ENDPOINT}..."
+              SNAPSHOT_DIGEST=$(mithril-client cardano-db snapshot list --json | jq -r '.[0].hash')
+              echo "Latest snapshot digest: ${SNAPSHOT_DIGEST}"
+            fi
+
+            mkdir -p /data
+            cd /data
+            echo "Starting mithril snapshot download..."
+            echo "Command: mithril-client cardano-db download ${SNAPSHOT_DIGEST} ${ANCILLARY_VERIFICATION_KEY:+--include-ancillary}"
+            echo "(This could take a while...)"
+            # Handle SIGTERM during download
+            trap 'kill -TERM $(pidof mithril-client) 2>/dev/null' TERM
+            # Run mithril-client in the background so we can capture the PID and wait
+            mithril-client cardano-db download "${SNAPSHOT_DIGEST}" ${ANCILLARY_VERIFICATION_KEY:+--include-ancillary} &
+            _mithril_pid=$!
+            wait $_mithril_pid || exit $?
+            # Reset signal handler and wait again (to avoid race condition)
+            trap - TERM
+            wait $_mithril_pid || exit $?
+            echo "Mithril snapshot download complete"
+        env:
+          - name: FORCE_REDOWNLOAD
+            value: {{ .Values.mithril.forceRedownload | quote }}
+          - name: DEBUG_INIT
+            value: {{ .Values.mithril.debugInit | quote }}
+        volumeMounts:
+          - name: node-db
+            mountPath: /data
+        {{- if .Values.mithril.resources }}
+        resources: {{- toYaml .Values.mithril.resources | nindent 12 }}
+        {{- end }}
+{{- end }}
       containers:
       - args:
         - run
@@ -46,8 +169,10 @@ spec:
           value: /ipc/node.socket
         - name: CARDANO_TOPOLOGY
           value: "/opt/cardano/config/{{ .Values.cardano_network }}/topology.json"
+{{- if not .Values.mithril.enabled }}
         - name: RESTORE_SNAPSHOT
-          value: "{{ .Values.restoreSnapshot }}"   
+          value: {{ .Values.restoreSnapshot | quote }}
+{{- end }}
 {{- if .Values.blockProducer.enabled }}
         - name: CARDANO_BLOCK_PRODUCER
           value: "true"

--- a/charts/cardano-node/values.yaml
+++ b/charts/cardano-node/values.yaml
@@ -22,8 +22,35 @@ service:
     metrics:
       port: 12798
       targetPort: 12798
-# Mithril
-restoreSnapshot: true
+
+# Mithril snapshot restoration in the main container
+restoreSnapshot: false
+
+# Mithril snapshot restoration via initContainer
+mithril:
+  # Enable Mithril snapshot download via initContainer (recommended)
+  # Runs mithril-client in initContainer before the main cardano-node container starts
+  enabled: true
+  # Genesis and ancillary keys - read from image config files by default
+  # These are fallbacks if /opt/cardano/config/{network}/*.vkey files don't exist
+  genesisVerificationKey: ""  # Optional: fallback if image doesn't have genesis.vkey
+  ancillaryVerificationKey: ""  # Optional: fallback if image doesn't have ancillary.vkey
+  snapshotDigest: ""  # Specific snapshot digest to download (leave empty for latest)
+  # Force re-download of mithril snapshot even if data exists
+  # Useful for updating to a newer snapshot
+  # WARNING: This will delete existing database data
+  forceRedownload: false
+  # Enable debug logging in init container (shows directory listings, etc.)
+  debugInit: false
+  # Optional resource limits for the mithril initContainer
+  resources: {}
+    # limits:
+    #   cpu: 2
+    #   memory: 4Gi
+    # requests:
+    #   cpu: 1
+    #   memory: 2Gi
+
 blockProducer:
   enabled: false
 # These are placeholder keys used as an example. You will need to generate your own.


### PR DESCRIPTION
Closes #11 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Mithril snapshot download to the cardano-node Helm chart via an initContainer to speed up initial sync and simplify configuration. Bumps chart version to 0.7.0 and changes restoreSnapshot default to false.

- **New Features**
  - InitContainer runs mithril-client to download the Cardano DB snapshot before the node starts; skips if /data/db/protocolMagicId exists unless forceRedownload is true.
  - Auto-selects the correct Mithril aggregator endpoint based on network (mainnet, preprod, preview).
  - Reads genesis/ancillary verification keys from image files when present, with Helm value fallbacks.
  - Supports pinning a snapshot via snapshotDigest or fetching the latest when unset.
  - Optional debug logging and resource configuration for the initContainer.

- **Migration**
  - Ensure your image includes mithril-client and jq, and provides /opt/cardano/config/{network}/genesis.vkey and ancillary.vkey, or set mithril.genesisVerificationKey and mithril.ancillaryVerificationKey.
  - Set mithril.snapshotDigest to pin a specific snapshot, or leave empty to use the latest.
  - Use mithril.forceRedownload=true to refresh the DB from a newer snapshot; this will delete /data/db.
  - The main-container restoreSnapshot now defaults to false; use the initContainer workflow (mithril.enabled=true).

<sup>Written for commit 2c91d182d120e8e750d6f9e383194d59a706af5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mithril-based snapshot restore can run as a configurable init-step (toggleable) with options for verification keys, optional snapshot digest, forced re-download, debug logging, and resource settings; when enabled, the main container no longer performs the restore.

* **Chores**
  * Chart version bumped to 0.7.0.
  * Default restore behavior moved to the init-step and is disabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->