### PR TITLE
feat(ext-ogmios-operator): Remove unsuported env

### DIFF
--- a/charts/ext-ogmios-operator/Chart.yaml
+++ b/charts/ext-ogmios-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: ext-ogmios-operator
 description: Extention Ogmios operator
-version: 0.0.1
-appVersion: "0.0.1"
+version: 0.0.2
+appVersion: "0.0.2"
 
 sources:
   - https://github.com/demeter-run/ext-cardano-ogmios

--- a/charts/ext-ogmios-operator/templates/deployment.yaml
+++ b/charts/ext-ogmios-operator/templates/deployment.yaml
@@ -26,8 +26,6 @@ spec:
               value: {{ .Values.extensionName | quote }}
             - name: API_KEY_SALT
               value: {{ .Values.apiKeySalt | quote }}
-            - name: DCU_PER_FRAME
-              value: "mainnet={{ .Values.perFrameDcus.mainnet }},preprod={{ .Values.perFrameDcus.default }},preview={{ .Values.perFrameDcus.default }},sanchonet={{ .Values.perFrameDcus.default }}"
             - name: METRICS_DELAY
               value: {{ .Values.metricsDelay | quote }}
             - name: PROMETHEUS_URL

--- a/charts/ext-ogmios-operator/values.yaml
+++ b/charts/ext-ogmios-operator/values.yaml
@@ -14,14 +14,6 @@ apiKeySalt: "change-me"
 dnsZone: "example.com"
 extensionName: "ogmios"
 
-# DCU per frame configuration
-perFrameDcus:
-  mainnet: "10"
-  preprod: "5"
-  preview: "5"
-  sanchonet: "5"
-  default: "5"
-
 resources:
   limits:
     cpu: "100m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unsupported DCU_PER_FRAME env var from the ext-ogmios-operator chart and bumped chart/app version to 0.0.2. This simplifies configuration and prevents invalid env usage.

- **Refactors**
  - Removed DCU_PER_FRAME from templates/deployment.yaml.
  - Deleted perFrameDcus config from values.yaml.
  - Updated Chart.yaml version and appVersion to 0.0.2.

<sup>Written for commit 0462cb8fb346c77b46d9daf2a15e2974e6259466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.0.2 for the Ogmios Operator Helm chart
  * Removed DCU per frame configuration option and associated environment variable
  * Simplified deployment settings for mainnet, preprod, preview, and sanchonet networks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->