### PR TITLE
feat: wireguard chart

### DIFF
--- a/.github/workflows/helmchart-testing.yml
+++ b/.github/workflows/helmchart-testing.yml
@@ -61,9 +61,18 @@ jobs:
           for chart_path in "${chart_array[@]}"; do
             chart_name=$(basename "$chart_path")
             echo "Installing $chart_name from $chart_path..."
+            # Build values file arguments from ci/ directory (same pattern as ct install)
+            values_args=""
+            for values_file in "$chart_path"/ci/*-values.yaml "$chart_path"/ci/values-*.yaml; do
+              if [[ -f "$values_file" ]]; then
+                echo "  Using values file: $values_file"
+                values_args="$values_args -f $values_file"
+              fi
+            done
             helm install "$chart_name" "$chart_path" \
               --namespace "${chart_name}-ci" \
               --create-namespace \
               --wait=false \
-              --timeout 30s
+              --timeout 30s \
+              $values_args
           done

--- a/.github/workflows/publish-wireguard-helm-chart.yml
+++ b/.github/workflows/publish-wireguard-helm-chart.yml
@@ -1,0 +1,33 @@
+name: publish-wireguard-helm-chart
+
+on:
+  push:
+    branches: ['main']
+    paths: ['charts/wireguard/**','.github/workflows/publish-wireguard-helm-chart.yml']
+
+jobs:
+  build-and-push-wireguard-helm-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6.0.1
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      - name: Package and upload chart
+        shell: bash
+        env:
+          REGISTRY: "ghcr.io"
+          REPOSITORY: "${{ github.repository }}"
+          TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          USER: "${{ github.repository_owner }}"
+        run: |
+          set -eo pipefail
+          rm -rf dist
+          mkdir dist
+          helm package charts/wireguard/ -d dist/
+          echo "${TOKEN}" | helm registry login "${REGISTRY}" -u "${USER}" --password-stdin
+          for file in dist/*; do
+            helm push "$file" "oci://${REGISTRY}/${REPOSITORY,,}/charts"
+          done

--- a/charts/wireguard/.helmignore
+++ b/charts/wireguard/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/wireguard/Chart.yaml
+++ b/charts/wireguard/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: wireguard
+description: WireGuard VPN server with JWT-authenticated peer management API
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+maintainers:
+  - name: aurora
+    email: aurora@blinklabs.io
+  - name: verbotenj
+    email: verbotenj@blinklabs.io
+  - name: wolf31o2
+    email: wolf31o2@blinklabs.io
+sources:
+  - https://github.com/blinklabs-io/docker-wireguard
+keywords:
+  - wireguard
+  - vpn
+  - dvpn
+  - cardano

--- a/charts/wireguard/ci/test-values.yaml
+++ b/charts/wireguard/ci/test-values.yaml
@@ -1,0 +1,19 @@
+# CI test values for chart-testing
+# These values satisfy required fields for Helm install tests
+
+wireguard:
+  # Test endpoint for CI
+  endpoint: "test.wireguard.example.com:51820"
+  # Test private key (base64 encoded, for CI only)
+  privateKey: "YUd3Z0dIRGRnZGdmZ2hkZ2hkZ2hkZmdoZGZnaGRmZ2g="
+
+api:
+  # Test JWT public key (Ed25519 PEM format, for CI only)
+  jwtPublicKey: |
+    -----BEGIN PUBLIC KEY-----
+    MCowBQYDK2VwAyEAtest1234567890abcdefghijklmnopqrstuvwxyz=
+    -----END PUBLIC KEY-----
+
+# Use ClusterIP for CI (no LoadBalancer in kind cluster)
+service:
+  type: ClusterIP

--- a/charts/wireguard/templates/_helpers.tpl
+++ b/charts/wireguard/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wireguard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "wireguard.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wireguard.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "wireguard.labels" -}}
+helm.sh/chart: {{ include "wireguard.chart" . }}
+{{ include "wireguard.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wireguard.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wireguard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app: wireguard
+region: {{ .Values.region }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wireguard.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "wireguard.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get the WireGuard private key secret name
+*/}}
+{{- define "wireguard.secretName" -}}
+{{- if .Values.wireguard.existingSecret }}
+{{- .Values.wireguard.existingSecret }}
+{{- else }}
+{{- printf "%s-keys" (include "wireguard.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get the JWT public key ConfigMap name
+*/}}
+{{- define "wireguard.jwtConfigMapName" -}}
+{{- if .Values.api.existingJwtConfigMap }}
+{{- .Values.api.existingJwtConfigMap }}
+{{- else }}
+{{- printf "%s-jwt-pubkey" (include "wireguard.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/charts/wireguard/templates/configmap.yaml
+++ b/charts/wireguard/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.api.existingJwtConfigMap }}
+{{- $jwt := required "api.jwtPublicKey is required when api.existingJwtConfigMap is not set" .Values.api.jwtPublicKey }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wireguard.fullname" . }}-jwt-pubkey
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+data:
+  jwt-verify.pub: |
+    {{- $jwt | nindent 4 }}
+{{- end }}

--- a/charts/wireguard/templates/deployment.yaml
+++ b/charts/wireguard/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wireguard.fullname" . }}
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "wireguard.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "wireguard.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "wireguard.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: wireguard
+              containerPort: {{ .Values.wireguard.port }}
+              protocol: UDP
+            - name: api
+              containerPort: {{ .Values.api.port }}
+              protocol: TCP
+          env:
+            - name: WG_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wireguard.secretName" . }}
+                  key: private-key
+            - name: WG_ENDPOINT
+              value: {{ .Values.wireguard.endpoint | quote }}
+            - name: WG_PORT
+              value: {{ .Values.wireguard.port | quote }}
+            - name: WG_SUBNET
+              value: {{ .Values.wireguard.subnet | quote }}
+            - name: WG_DNS
+              value: {{ .Values.wireguard.dns | quote }}
+            - name: ENABLE_NAT
+              value: {{ .Values.wireguard.enableNat | ternary "1" "0" | quote }}
+            - name: NAT_DEVICE
+              value: {{ .Values.wireguard.natDevice | quote }}
+            - name: API_LISTEN
+              value: {{ .Values.api.listen | quote }}
+            - name: JWT_PUBLIC_KEY_FILE
+              value: /etc/wireguard/jwt-verify.pub
+            - name: DEBUG
+              value: {{ .Values.debug | ternary "1" "0" | quote }}
+          volumeMounts:
+            - name: jwt-pubkey
+              mountPath: /etc/wireguard/jwt-verify.pub
+              subPath: jwt-verify.pub
+              readOnly: true
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: jwt-pubkey
+          configMap:
+            name: {{ include "wireguard.jwtConfigMapName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/wireguard/templates/networkpolicy.yaml
+++ b/charts/wireguard/templates/networkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $apiLabels := required "networkPolicy.apiAllowedPodLabels is required when networkPolicy.enabled is true" .Values.networkPolicy.apiAllowedPodLabels }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wireguard.fullname" . }}
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wireguard.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.allowWireguardFromAnywhere }}
+    # WireGuard UDP from anywhere
+    - ports:
+        - port: {{ .Values.wireguard.port }}
+          protocol: UDP
+    {{- end }}
+    # API only from allowed pods (e.g., vpn-indexer)
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- toYaml $apiLabels | nindent 14 }}
+      ports:
+        - port: {{ .Values.api.port }}
+          protocol: TCP
+  egress:
+    # Allow all outbound (VPN traffic needs internet access)
+    - {}
+{{- end }}

--- a/charts/wireguard/templates/poddisruptionbudget.yaml
+++ b/charts/wireguard/templates/poddisruptionbudget.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- $hasMinAvailable := hasKey .Values.podDisruptionBudget "minAvailable" }}
+{{- $hasMaxUnavailable := hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+{{- if not (or $hasMinAvailable $hasMaxUnavailable) }}
+{{- fail "podDisruptionBudget.enabled is true but neither minAvailable nor maxUnavailable is set" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "wireguard.fullname" . }}
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+spec:
+  {{- if $hasMaxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else if $hasMinAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "wireguard.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/wireguard/templates/podmonitor.yaml
+++ b/charts/wireguard/templates/podmonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "wireguard.fullname" . }}
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+    {{- with .Values.podMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.podMonitor.fallbackScrapeProtocol }}
+  fallbackScrapeProtocol: {{ . | quote }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "wireguard.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    {{- toYaml .Values.podMonitor.podMetricsEndpoints | nindent 4 }}
+{{- end }}

--- a/charts/wireguard/templates/secret.yaml
+++ b/charts/wireguard/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.wireguard.existingSecret }}
+{{- $pk := required "wireguard.privateKey is required when wireguard.existingSecret is not set" .Values.wireguard.privateKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wireguard.fullname" . }}-keys
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+type: Opaque
+data:
+  private-key: {{ $pk | b64enc | quote }}
+{{- end }}

--- a/charts/wireguard/templates/service-api.yaml
+++ b/charts/wireguard/templates/service-api.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wireguard.fullname" . }}-api
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+  {{- with .Values.apiService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.apiService.type }}
+  ports:
+    - port: {{ .Values.apiService.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+  selector:
+    {{- include "wireguard.selectorLabels" . | nindent 4 }}

--- a/charts/wireguard/templates/service-wireguard.yaml
+++ b/charts/wireguard/templates/service-wireguard.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wireguard.fullname" . }}
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  externalTrafficPolicy: Local
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: wireguard
+      protocol: {{ .Values.service.protocol }}
+      name: wireguard
+  selector:
+    {{- include "wireguard.selectorLabels" . | nindent 4 }}

--- a/charts/wireguard/templates/serviceaccount.yaml
+++ b/charts/wireguard/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wireguard.serviceAccountName" . }}
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/wireguard/templates/tests/test.yaml
+++ b/charts/wireguard/templates/tests/test.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "wireguard.fullname" . }}-test-connection"
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command: ['wget']
+      args: ['http://{{ include "wireguard.fullname" . }}-api:{{ .Values.apiService.port }}/health', '-O', '-', '-q']

--- a/charts/wireguard/values.yaml
+++ b/charts/wireguard/values.yaml
@@ -1,0 +1,153 @@
+# WireGuard VPN Server Helm Chart
+# https://github.com/blinklabs-io/docker-wireguard
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/blinklabs-io/docker-wireguard
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# WireGuard configuration
+wireguard:
+  # Server private key (base64 encoded)
+  # Can be provided directly or via existingSecret
+  privateKey: ""
+  # Reference to existing secret containing WireGuard private key
+  # Secret must have key: private-key
+  existingSecret: ""
+  # Public endpoint that clients will connect to
+  # Should be set to your actual endpoint, e.g., "vpn.example.com:51820"
+  endpoint: "wireguard.example.com:51820"
+  # WireGuard listen port
+  port: 51820
+  # Server subnet (CIDR)
+  subnet: "10.8.0.0/24"
+  # DNS server pushed to clients
+  dns: "1.1.1.1"
+  # Enable NAT/masquerading
+  enableNat: true
+  # NAT outbound device (usually auto-detected)
+  natDevice: "eth0"
+
+# Peer Management API configuration
+api:
+  # API listen address
+  listen: ":8080"
+  # Port for the API service
+  port: 8080
+  # JWT public key for verifying peer registration requests
+  # Ed25519 public key in PEM format
+  jwtPublicKey: ""
+  # Reference to existing ConfigMap containing JWT public key
+  # ConfigMap must have key: jwt-verify.pub
+  existingJwtConfigMap: ""
+
+# Region identifier (used for labeling and identification)
+region: "us1"
+
+# Debug mode
+debug: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# Security context - NET_ADMIN required for WireGuard
+securityContext:
+  capabilities:
+    add:
+      - NET_ADMIN
+
+# WireGuard UDP service (LoadBalancer for external access)
+service:
+  type: LoadBalancer
+  port: 51820
+  protocol: UDP
+  annotations: {}
+    # AWS NLB example:
+    # service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    # service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    # service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+
+# Internal API service (ClusterIP for vpn-indexer communication)
+apiService:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+resources: {}
+  # We recommend setting appropriate limits
+  # limits:
+  #   cpu: 500m
+  #   memory: 256Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 64Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Network policy configuration
+networkPolicy:
+  enabled: true
+  # Allow WireGuard UDP from anywhere
+  allowWireguardFromAnywhere: true
+  # Restrict API access to specific pod labels
+  apiAllowedPodLabels:
+    app: vpn-indexer
+
+# Pod disruption budget
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# Prometheus PodMonitor
+podMonitor:
+  enabled: false
+  extraLabels: {}
+  # For Prometheus v3.0.0+ compatibility
+  fallbackScrapeProtocol: ""
+  podMetricsEndpoints:
+    - port: api
+      path: /metrics
+      interval: 30s
+      scheme: http
+
+# Liveness and readiness probes
+livenessProbe:
+  httpGet:
+    path: /health
+    port: api
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: api
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Helm chart to deploy a WireGuard VPN server with a JWT-secured peer management API on Kubernetes. Includes a GitHub Action that packages and publishes the chart to GHCR on pushes to main.

- **New Features**
  - Helm chart with Deployment, ServiceAccount, Secrets/ConfigMaps, NetworkPolicy, PodDisruptionBudget, PodMonitor, and a test hook.
  - Two services: UDP LoadBalancer for WireGuard and ClusterIP for the API.
  - Configurable values for endpoint, ports, subnet/DNS, NAT, region label, and JWT key sources (existing ConfigMap or inline).
  - Container runs with NET_ADMIN; network policy limits API access to allowed pods.

- **Migration**
  - Set wireguard.endpoint and provide the private key via wireguard.privateKey or wireguard.existingSecret.
  - Provide the JWT public key via api.jwtPublicKey or api.existingJwtConfigMap.
  - Add cloud load balancer annotations if needed; open UDP on the chosen port.
  - Adjust networkPolicy.apiAllowedPodLabels to match your API callers, or disable the policy.

<sup>Written for commit 4e139dcb7c25cc2458d321c5a91d2ea69a6bbc59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WireGuard Helm chart with configurable VPN server, API (JWT support), Services, NetworkPolicy, PodDisruptionBudget, PodMonitor (Prometheus) and extensive customization.

* **Tests**
  * Added a Helm test hook to validate the API health endpoint after deployment.

* **Chores**
  * Added CI workflows to package/publish the chart to an OCI registry and to include chart-specific CI values during installs; added packaging ignore rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->