### PR TITLE
chore: cardano-node-api 0.10.0

### DIFF
--- a/charts/cardano-node-api/Chart.yaml
+++ b/charts/cardano-node-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cardano-node-api
 description: Creates a Cardano Node API deployment
-version: 0.0.14
-appVersion: 0.9.2
+version: 0.0.15
+appVersion: 0.10.0
 maintainers:
   - name: aurora
     email: aurora@blinklabs.io

--- a/charts/cardano-node-api/values.yaml
+++ b/charts/cardano-node-api/values.yaml
@@ -8,7 +8,7 @@ cardano_node:
   skip_check: true
 image:
   repository: ghcr.io/blinklabs-io/cardano-node-api
-  tag: 0.9.2
+  tag: 0.10.0
 replicaCount: 1
 resources: {}
 tolerations:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the cardano-node-api Helm chart to 0.0.15 and set app/image version to 0.10.0 so deployments use the latest release.

<sup>Written for commit 1bf40d00ef5e4df38464940b1c30ababac2d1e4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cardano Node API to version 0.10.0 and bumped Helm chart version to 0.0.15.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->