### PR TITLE
feat(cardano-node): configurable updateStrategy defaults to onDelete

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.7.2
+version: 0.7.3
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -248,7 +248,7 @@ spec:
           secretName: {{ .Release.Name }}-secret
 {{- end }}
   updateStrategy:
-    type: OnDelete
+    type: {{ .Values.updateStrategy | default "OnDelete" }}
   volumeClaimTemplates:
   - metadata:
       labels:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the StatefulSet updateStrategy configurable via Helm values while keeping the default as OnDelete. Also bumps the chart version to 0.7.3.

- **Migration**
  - Set values.updateStrategy (e.g., RollingUpdate) in values.yaml if you want automatic pod updates; no action needed to keep OnDelete.

<sup>Written for commit d2ae7c3a872ad2b8b01cdac7d17677dbda8e0ed0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped chart version to 0.7.3

* **Improvements**
  * StatefulSet update strategy is now configurable via Helm chart values, allowing customization while maintaining backward compatibility with the default "OnDelete" behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->