### PR TITLE
feat(cardano-node): add checksum annotations for block producer keys and topology

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.7.3
+version: 0.7.4
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -15,6 +15,12 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         kubectl.kubernetes.io/default-container: cardano-node
+{{- if .Values.blockProducer.enabled }}                                                                                                                                                               
+        checksum/keys: {{ .Values.blockProducer.keys | toJson | sha256sum }}                                                                                                                          
+{{- end }}                                                                                                                                                                                            
+{{- if .Values.topology.enabled }}                                                                                                                                                                    
+        checksum/topology: {{ .Values.topology | toJson | sha256sum }}                                                                                                                                
+{{- end }}
       labels:
 {{ include "cardano-node.labels" . | indent 8 }}
 {{- with .Values.extraPodLabels }}


### PR DESCRIPTION
Track checksums of block producer keys and topology values as pod template annotations.

Closes #327

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add checksum annotations to the cardano-node StatefulSet to detect changes in block producer keys and topology and trigger rollouts when their data changes. This makes secret/configmap updates take effect without renaming resources.

- **New Features**
  - Add pod template annotations: checksum/keys (from .Values.blockProducer.keys) and checksum/topology (from .Values.topology), only when enabled.
  - Rollouts occur on checksum changes and can be controlled via StatefulSet updateStrategy. Chart version bumped to 0.7.4.

<sup>Written for commit 40079619abde6d911aaefcde9dbdc31af922f2fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cardano node Helm chart version from 0.7.3 to 0.7.4

* **New Features**
  * Added conditional checksum annotations to the StatefulSet template that automatically compute and attach configuration checksums for block producer keys and topology when their respective options are enabled

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->