### PR TITLE
chore(dingo): bump dingo to 0.21.0

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo"
-version: 0.0.25
-appVersion: 0.20.0
+version: 0.0.26
+appVersion: 0.21.0
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.20.0"
+  tag: "0.21.0"
   pullPolicy: IfNotPresent
 
 mithril:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade the Dingo Helm chart to deploy Dingo v0.21.0. Bumps chart version to 0.0.26 and updates the image tag to 0.21.0.

<sup>Written for commit 401a7a7f768c3d8099f4b5c7301d3089c846da11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dingo to version 0.21.0, including the corresponding container image tag update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->