### PR TITLE
feat: add RollingUpdate updateStrategy to all helm charts

### DIFF
--- a/.github/workflows/helmchart-testing.yml
+++ b/.github/workflows/helmchart-testing.yml
@@ -1,4 +1,4 @@
-name: Lint & Test Charts
+name: Lint Charts
 on: pull_request
 
 jobs:
@@ -39,40 +39,3 @@ jobs:
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
-
-      - name: Create kind cluster
-        if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
-
-      - name: Run chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true'
-        continue-on-error: true
-        run: |
-          # Additional arguments for Helm. Must be passed as a single quoted string
-          # https://github.com/helm/chart-testing/blob/main/doc/ct_install.md
-          ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args='--timeout 300s'
-
-      - name: Helm install fallback for changed charts
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          echo "Running Helm installs for changed charts..."
-          charts="${{ steps.list-changed.outputs.changed_charts }}"
-          IFS=',' read -ra chart_array <<< "$charts"
-          for chart_path in "${chart_array[@]}"; do
-            chart_name=$(basename "$chart_path")
-            echo "Installing $chart_name from $chart_path..."
-            # Build values file arguments from ci/ directory (same pattern as ct install)
-            values_args=""
-            for values_file in "$chart_path"/ci/*-values.yaml "$chart_path"/ci/values-*.yaml; do
-              if [[ -f "$values_file" ]]; then
-                echo "  Using values file: $values_file"
-                values_args="$values_args -f $values_file"
-              fi
-            done
-            helm install "$chart_name" "$chart_path" \
-              --namespace "${chart_name}-ci" \
-              --create-namespace \
-              --wait=false \
-              --timeout 30s \
-              $values_args
-          done

--- a/charts/adder/Chart.yaml
+++ b/charts/adder/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: adder
 description: "A Helm chart for deploying Adder"
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.34.0
 
 sources:

--- a/charts/adder/templates/deployment.yaml
+++ b/charts/adder/templates/deployment.yaml
@@ -11,6 +11,10 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "adder.selectorLabels" . | nindent 6 }}

--- a/charts/adder/values.yaml
+++ b/charts/adder/values.yaml
@@ -1,6 +1,9 @@
 ---
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: "ghcr.io/blinklabs-io/adder"
   tag: "0.34.0"

--- a/charts/balius-operator/Chart.yaml
+++ b/charts/balius-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: balius-operator
 description: Balius operator
-version: 0.0.1
+version: 0.0.2
 appVersion: "0.0.1"
 
 sources:

--- a/charts/balius-operator/templates/deployment.yaml
+++ b/charts/balius-operator/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels: {{ include "baliusOperator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{ include "baliusOperator.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/balius-operator/values.yaml
+++ b/charts/balius-operator/values.yaml
@@ -1,5 +1,9 @@
 # Balius Operator values
 replicaCount: 1
+
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/demeter-run/ext-balius-operator
   tag: latest

--- a/charts/balius/Chart.yaml
+++ b/charts/balius/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: balius
 description: Balius server
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.0.1"
 
 sources:

--- a/charts/balius/templates/deployment.yaml
+++ b/charts/balius/templates/deployment.yaml
@@ -9,11 +9,15 @@ metadata:
     cardano_network: {{ .Values.balius.network }}
 spec:
   replicas: {{ .Values.balius.replicas }}
+  {{- if .Values.balius.updateStrategy }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.balius.updateStrategy.type }}
+    {{- if eq .Values.balius.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
       maxSurge: {{ .Values.balius.rollingUpdate.maxSurge }}
       maxUnavailable: {{ .Values.balius.rollingUpdate.maxUnavailable }}
+    {{- end }}
+  {{- end }}
   selector:
     matchLabels: {{- include "balius.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/balius/values.yaml
+++ b/charts/balius/values.yaml
@@ -25,6 +25,8 @@ balius:
   affinity: {}
   podLabels: {}
   podAnnotations: {}
+  updateStrategy:
+    type: RollingUpdate
   rollingUpdate:
     maxSurge: 1
     maxUnavailable: 0

--- a/charts/bind9/Chart.yaml
+++ b/charts/bind9/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bind9
 description: "A Helm chart for deploying BIND9 DNS resolver"
-version: 0.0.4
+version: 0.0.5
 appVersion: "9.18"
 
 sources:

--- a/charts/bind9/templates/statefulset.yaml
+++ b/charts/bind9/templates/statefulset.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   serviceName: {{ include "bind9.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "bind9.selectorLabels" . | nindent 6 }}

--- a/charts/bind9/values.yaml
+++ b/charts/bind9/values.yaml
@@ -1,6 +1,9 @@
 ---
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ubuntu/bind9
   pullPolicy: Always

--- a/charts/bluefin/Chart.yaml
+++ b/charts/bluefin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bluefin
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.13.2"
 maintainers:
   - name: aurora

--- a/charts/bluefin/templates/deployment.yaml
+++ b/charts/bluefin/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "bluefin.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "bluefin.selectorLabels" . | nindent 6 }}

--- a/charts/bluefin/values.yaml
+++ b/charts/bluefin/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/blinklabs-io/bluefin
   pullPolicy: IfNotPresent

--- a/charts/bursa/Chart.yaml
+++ b/charts/bursa/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bursa
 description: "A Helm chart for deploying Bursa"
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.11.1
 
 sources:

--- a/charts/bursa/templates/deployment.yaml
+++ b/charts/bursa/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "bursa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "bursa.name" . }}

--- a/charts/bursa/values.yaml
+++ b/charts/bursa/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/blinklabs-io/bursa
   tag: "0.11.1"

--- a/charts/butane-oracle/Chart.yaml
+++ b/charts/butane-oracle/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: butane-oracle
 description: Helm chart for SundaeSwap butane-oracle
-version: 0.1.5
+version: 0.1.6
 appVersion: "v0.25.4"
 type: application
 maintainers:

--- a/charts/butane-oracle/templates/deployment.yaml
+++ b/charts/butane-oracle/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- include "butane-oracle.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount | default 1 }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "butane-oracle.selectorLabels" . | nindent 6 }}

--- a/charts/butane-oracle/values.yaml
+++ b/charts/butane-oracle/values.yaml
@@ -5,6 +5,9 @@ nameOverride: ""
 # Override the full name of the app
 fullnameOverride: ""
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: "sundaeswap/butane-oracle"
   tag: "v0.25.4"

--- a/charts/cardano-node-api/Chart.yaml
+++ b/charts/cardano-node-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node-api
 description: Creates a Cardano Node API deployment
-version: 0.0.15
+version: 0.0.16
 appVersion: 0.10.0
 maintainers:
   - name: aurora

--- a/charts/cardano-node-api/templates/deployment.yaml
+++ b/charts/cardano-node-api/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "cardano-node-api.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       cardano_network: {{ .Values.cardano_network }}

--- a/charts/cardano-node-api/values.yaml
+++ b/charts/cardano-node-api/values.yaml
@@ -1,6 +1,9 @@
 ---
 nameOverride: ""
 
+updateStrategy:
+  type: RollingUpdate
+
 cardano_network: preview
 cardano_node:
   host: cardano-node-headless

--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.8.0
+version: 0.8.1
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/values.yaml
+++ b/charts/cardano-node/values.yaml
@@ -1,4 +1,6 @@
 ---
+updateStrategy: RollingUpdate
+
 cardano_network: preview
 # extraPodLabels: {}
 image:

--- a/charts/cdnsd/Chart.yaml
+++ b/charts/cdnsd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cdnsd
 description: "A Helm chart for deploying cdnsd"
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.22.1
 
 sources:

--- a/charts/cdnsd/templates/statefulset.yaml
+++ b/charts/cdnsd/templates/statefulset.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   serviceName: {{ include "cdnsd.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cdnsd.selectorLabels" . | nindent 6 }}

--- a/charts/cdnsd/values.yaml
+++ b/charts/cdnsd/values.yaml
@@ -1,6 +1,9 @@
 ---
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: "ghcr.io/blinklabs-io/cdnsd"
   tag: "0.22.1"

--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo"
-version: 0.0.26
+version: 0.0.27
 appVersion: 0.21.0
 
 sources:

--- a/charts/dingo/templates/statefulset.yaml
+++ b/charts/dingo/templates/statefulset.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   serviceName: {{ include "dingo.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "dingo.name" . }}

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -1,6 +1,9 @@
 ---
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/blinklabs-io/dingo
   tag: "0.21.0"

--- a/charts/dolos/Chart.yaml
+++ b/charts/dolos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dolos
 description: Dolos server
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.32.0"
 
 sources:

--- a/charts/dolos/templates/sts.yaml
+++ b/charts/dolos/templates/sts.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ .Values.service.name | default .Release.Name }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "dolos.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/dolos/values.yaml
+++ b/charts/dolos/values.yaml
@@ -1,4 +1,8 @@
 replicaCount: 1
+
+updateStrategy:
+  type: RollingUpdate
+
 network: preview
 
 # Optional custom peer address. If not set, a default public peer will be used.

--- a/charts/ergo-node/Chart.yaml
+++ b/charts/ergo-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ergo-node
 description: Ergo protocol description & reference client implementation
-version: 0.3.0
+version: 0.3.1
 appVersion: v6.1.0
 maintainers:
   - name: wolf31o2

--- a/charts/ergo-node/templates/statefulset.yaml
+++ b/charts/ergo-node/templates/statefulset.yaml
@@ -62,8 +62,10 @@ spec:
             subPath: ergo.conf
           - name: ergo-data-{{ include "ergo-node.network" . }}
             mountPath: /home/ergo/.ergo
+  {{- if .Values.updateStrategy }}
   updateStrategy:
-    type: OnDelete
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   volumeClaimTemplates:
   - metadata:
       labels:

--- a/charts/ergo-node/values.yaml
+++ b/charts/ergo-node/values.yaml
@@ -1,4 +1,7 @@
 ---
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ergoplatform/ergo
   tag: v6.1.0

--- a/charts/ext-cardano-node-operator/Chart.yaml
+++ b/charts/ext-cardano-node-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ext-cardano-node-operator
 description: Extention Cardano Node operator
-version: 0.0.1
+version: 0.0.2
 appVersion: "0.0.1"
 
 sources:

--- a/charts/ext-cardano-node-operator/templates/deployment.yaml
+++ b/charts/ext-cardano-node-operator/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels: {{ include "extCardanoNodeOperator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{ include "extCardanoNodeOperator.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/ext-cardano-node-operator/values.yaml
+++ b/charts/ext-cardano-node-operator/values.yaml
@@ -1,5 +1,9 @@
 # cardano-node Operator values
 replicaCount: 1
+
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/demeter-run/ext-cardano-node-operator
   tag: latest

--- a/charts/ext-kupo-operator/Chart.yaml
+++ b/charts/ext-kupo-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ext-kupo-operator
 description: Extention Kupo operator
-version: 0.0.2
+version: 0.0.3
 appVersion: "0.0.2"
 
 sources:

--- a/charts/ext-kupo-operator/templates/deployment.yaml
+++ b/charts/ext-kupo-operator/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels: {{ include "extKupoOperator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{ include "extKupoOperator.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/ext-kupo-operator/values.yaml
+++ b/charts/ext-kupo-operator/values.yaml
@@ -1,5 +1,9 @@
 # Kupo Operator values
 replicaCount: 1
+
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/demeter-run/ext-cardano-kupo-operator
   tag: latest

--- a/charts/ext-ogmios-operator/Chart.yaml
+++ b/charts/ext-ogmios-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ext-ogmios-operator
 description: Extention Ogmios operator
-version: 0.0.2
+version: 0.0.3
 appVersion: "0.0.2"
 
 sources:

--- a/charts/ext-ogmios-operator/templates/deployment.yaml
+++ b/charts/ext-ogmios-operator/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels: {{ include "extOgmiosOperator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{ include "extOgmiosOperator.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/ext-ogmios-operator/values.yaml
+++ b/charts/ext-ogmios-operator/values.yaml
@@ -1,5 +1,9 @@
 # Ogmios Operator values
 replicaCount: 1
+
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/demeter-run/ext-cardano-ogmios-operator
   tag: latest

--- a/charts/ext-proxy/Chart.yaml
+++ b/charts/ext-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ext-proxy
 description: A Helm chart for managing different proxy configurations for https://github.com/demeter-run
-version: 0.0.4
+version: 0.0.5
 appVersion: "0.0.1"
 
 maintainers:

--- a/charts/ext-proxy/templates/proxy.yaml
+++ b/charts/ext-proxy/templates/proxy.yaml
@@ -7,6 +7,10 @@ metadata:
     role: {{ .Values.proxy.role }}
 spec:
   replicas: {{ .Values.proxy.replicas }}
+  {{- if .Values.proxy.updateStrategy }}
+  strategy:
+    type: {{ .Values.proxy.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       role: {{ .Values.proxy.role }}

--- a/charts/ext-proxy/values.yaml
+++ b/charts/ext-proxy/values.yaml
@@ -2,6 +2,8 @@
 proxy:
   role: &proxy_role demo-proxy
   replicas: 1
+  updateStrategy:
+    type: RollingUpdate
   serviceAccountName: "demo"
   env:
     - name: SSL_CRT_PATH

--- a/charts/ext-tx-submit-api-operator/Chart.yaml
+++ b/charts/ext-tx-submit-api-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ext-tx-submit-api-operator
 description: Ext Tx Submit API operator
-version: 0.0.2
+version: 0.0.3
 appVersion: "0.0.1"
 
 sources:

--- a/charts/ext-tx-submit-api-operator/templates/deployment.yaml
+++ b/charts/ext-tx-submit-api-operator/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels: {{ include "txSubmitApiOperator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{ include "txSubmitApiOperator.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/ext-tx-submit-api-operator/values.yaml
+++ b/charts/ext-tx-submit-api-operator/values.yaml
@@ -1,5 +1,9 @@
 # Ext Tx Submit API Operator values
 replicaCount: 1
+
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/demeter-run/ext-cardano-submitapi-operator
   tag: 414d79bfa36292404bb5ed93f6750fa5d43e434f

--- a/charts/handshake-node/Chart.yaml
+++ b/charts/handshake-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: handshake-node
 description: Deploys a Handshake node for specified network and a prometheus exporter for metrics
-version: 0.2.0
+version: 0.2.1
 appVersion: 8.0.0
 maintainers:
   - name: aurora

--- a/charts/handshake-node/templates/statefulset.yaml
+++ b/charts/handshake-node/templates/statefulset.yaml
@@ -146,8 +146,10 @@ spec:
         resources:
           {{- toYaml .Values.metrics.resources | nindent 10 }}
       {{- end }}
+  {{- if .Values.updateStrategy }}
   updateStrategy:
-    type: OnDelete
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   volumeClaimTemplates:
   - metadata:
       labels:

--- a/charts/handshake-node/values.yaml
+++ b/charts/handshake-node/values.yaml
@@ -1,4 +1,7 @@
 ---
+updateStrategy:
+  type: RollingUpdate
+
 # Network configuration (main for mainnet, testnet for testnet, regtest, etc.)
 handshake_network: main
 

--- a/charts/kupo/Chart.yaml
+++ b/charts/kupo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kupo
 description: "A Helm chart for deploying Kupo - fast, lightweight & configurable chain-index for Cardano"
-version: 0.0.5
+version: 0.0.6
 appVersion: "2.11.0"
 
 sources:

--- a/charts/kupo/templates/statefulset.yaml
+++ b/charts/kupo/templates/statefulset.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   serviceName: {{ include "kupo.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kupo.selectorLabels" . | nindent 6 }}

--- a/charts/kupo/values.yaml
+++ b/charts/kupo/values.yaml
@@ -1,6 +1,9 @@
 ---
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: cardanosolutions/kupo
   tag: "v2.11.0"

--- a/charts/ogmios/Chart.yaml
+++ b/charts/ogmios/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: ogmios
 description: Creates an Ogmios API service with SOCAT sidecar
-version: 0.0.8
+version: 0.0.9
 appVersion: v6.14.0
 maintainers:
   - name: aurora

--- a/charts/ogmios/templates/deployment.yaml
+++ b/charts/ogmios/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "ogmios.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{ include "ogmios.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/ogmios/values.yaml
+++ b/charts/ogmios/values.yaml
@@ -1,4 +1,7 @@
 ---
+updateStrategy:
+  type: RollingUpdate
+
 cardano_network: preview
 cardano_node:
   host: cardano-node-headless

--- a/charts/openvpn/Chart.yaml
+++ b/charts/openvpn/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openvpn
 description: A Helm chart for deploying OpenVPN in Kubernetes with an optional BIND sidecar
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "2.6.3"
 
 maintainers:

--- a/charts/openvpn/templates/deployment.yaml
+++ b/charts/openvpn/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "openvpn.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "openvpn.selectorLabels" . | nindent 6 }}

--- a/charts/openvpn/values.yaml
+++ b/charts/openvpn/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: blinklabs/openvpn
   pullPolicy: IfNotPresent

--- a/charts/tx-submit-api-mirror/Chart.yaml
+++ b/charts/tx-submit-api-mirror/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tx-submit-api-mirror
 description: Creates a Cardano Tx Submit API mirror service deployment
-version: 0.0.9
+version: 0.0.10
 appVersion: 0.8.1
 maintainers:
   - name: aurora

--- a/charts/tx-submit-api-mirror/templates/deployment.yaml
+++ b/charts/tx-submit-api-mirror/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "tx-submit-api-mirror.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       cardano_network: {{ .Values.cardano_network }}

--- a/charts/tx-submit-api-mirror/values.yaml
+++ b/charts/tx-submit-api-mirror/values.yaml
@@ -1,4 +1,7 @@
 ---
+updateStrategy:
+  type: RollingUpdate
+
 backends:
 - http://one.example.com/api/submit/tx
 - http://another.example.com/api/submit/tx

--- a/charts/tx-submit-api/Chart.yaml
+++ b/charts/tx-submit-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tx-submit-api
 description: Creates a Cardano Tx Submit API deployment
-version: 0.1.18
+version: 0.1.19
 appVersion: 0.20.9
 maintainers:
   - name: aurora

--- a/charts/tx-submit-api/templates/deployment.yaml
+++ b/charts/tx-submit-api/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "tx-submit-api.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{ include "tx-submit-api.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/tx-submit-api/values.yaml
+++ b/charts/tx-submit-api/values.yaml
@@ -1,4 +1,7 @@
 ---
+updateStrategy:
+  type: RollingUpdate
+
 cardano_network: preview
 cardano_node:
   host: preview-node.play.dev.cardano.org:3001

--- a/charts/vpn-indexer/Chart.yaml
+++ b/charts/vpn-indexer/Chart.yaml
@@ -3,7 +3,7 @@ name: vpn-indexer
 description: VPN indexer helm chart
 type: application
 
-version: 0.5.5
+version: 0.5.6
 
 appVersion: "0.5.1"
 

--- a/charts/vpn-indexer/templates/statefulset.yaml
+++ b/charts/vpn-indexer/templates/statefulset.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   serviceName: {{ include "vpn-indexer.fullname" . }}-sts
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "vpn-indexer.selectorLabels" . | nindent 6 }}

--- a/charts/vpn-indexer/values.yaml
+++ b/charts/vpn-indexer/values.yaml
@@ -2,6 +2,9 @@
 
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/blinklabs-io/vpn-indexer
   pullPolicy: IfNotPresent

--- a/charts/wireguard/Chart.yaml
+++ b/charts/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: WireGuard VPN server with JWT-authenticated peer management API
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 maintainers:
   - name: aurora

--- a/charts/wireguard/templates/deployment.yaml
+++ b/charts/wireguard/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "wireguard.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "wireguard.selectorLabels" . | nindent 6 }}

--- a/charts/wireguard/values.yaml
+++ b/charts/wireguard/values.yaml
@@ -3,6 +3,9 @@
 
 replicaCount: 1
 
+updateStrategy:
+  type: RollingUpdate
+
 image:
   repository: ghcr.io/blinklabs-io/docker-wireguard
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Add updateStrategy configuration with RollingUpdate as default to 26 helm charts. This ensures consistent rolling update behavior across all deployments and statefulsets.

Changes:
- Added updateStrategy to values.yaml for all applicable charts
- Updated templates to use updateStrategy from values
- Deployments use strategy.type, StatefulSets use updateStrategy.type
- Replaced hardcoded OnDelete with templated values in ergo-node and handshake-node
- CI remove chart install test because it often relies on other parts of the infrastructure, and then tests are not useful

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable updateStrategy to 26 Helm charts with RollingUpdate as the default to standardize rollout behavior for Deployments and StatefulSets. Replaces hardcoded OnDelete in ergo-node and handshake-node, now configurable via values.

- **New Features**
  - Added updateStrategy in values for each chart; templates read it (Deployments: spec.strategy.type, StatefulSets: spec.updateStrategy.type).
  - Introduced chart-specific paths where needed (e.g., balius.updateStrategy, proxy.updateStrategy).

- **Migration**
  - Behavior change: ergo-node and handshake-node now default to RollingUpdate; set updateStrategy.type=OnDelete to keep previous behavior.
  - Override as needed by setting updateStrategy.type in chart values.

<sup>Written for commit cab06cc34ff3209ea6b492be23722a7df6d06fbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment update strategy is now configurable via chart values; defaults to RollingUpdate when not overridden.

* **Chores**
  * Bumped Helm chart versions across multiple services.
  * Simplified chart CI workflow (lint-only, removed install/test cluster steps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->