### PR TITLE
fix(ext-proxy): remove hardcoded ports in ext-proxy helm chart

### DIFF
--- a/charts/ext-proxy/Chart.yaml
+++ b/charts/ext-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ext-proxy
 description: A Helm chart for managing different proxy configurations for https://github.com/demeter-run
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.0.1"
 
 maintainers:

--- a/charts/ext-proxy/templates/podmonitor.yaml
+++ b/charts/ext-proxy/templates/podmonitor.yaml
@@ -13,6 +13,6 @@ spec:
     matchLabels:
       role: {{ .Values.proxy.role }}
   podMetricsEndpoints:
-  - port: metrics
+  - port: {{ .Values.podMonitor.metricsPort }}
     path: /metrics
 {{- end }}

--- a/charts/ext-proxy/templates/proxy.yaml
+++ b/charts/ext-proxy/templates/proxy.yaml
@@ -43,12 +43,11 @@ spec:
         env: {{ toYaml .Values.proxy.env | nindent 8 }}
         resources: {{ toYaml .Values.proxy.resources | nindent 10 }}
         ports:
-        - name: metrics
-          containerPort: {{ .Values.proxy.ports.metrics }}
+        {{- range $name, $port := .Values.proxy.ports }}
+        - name: {{ $name }}
+          containerPort: {{ $port }}
           protocol: TCP
-        - name: proxy
-          containerPort: {{ .Values.proxy.ports.proxy }}
-          protocol: TCP
+        {{- end }}
         volumeMounts:
         - name: certs
           mountPath: /certs

--- a/charts/ext-proxy/values.yaml
+++ b/charts/ext-proxy/values.yaml
@@ -52,6 +52,7 @@ init:
 podMonitor:
   enabled: false
   labels: {}
+  metricsPort: metrics
 
 # Extra config files to include in the ConfigMap alongside tiers.toml
 # Each key becomes a filename mounted at /configs/<key>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded ports in the ext-proxy Helm chart with a values-driven loop so ports are configurable and can include multiple entries. Made PodMonitor metrics port configurable via `podMonitor.metricsPort`; bumped chart version to 0.0.7.

<sup>Written for commit 7380963d97194c07e5cef1ce7300b5b4ccf8d123. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release version bumped to 0.0.7
  * Added a configurable metrics port for pod monitoring

* **Refactor**
  * Container port entries are now generated dynamically from customizable values, allowing flexible port configuration without template edits
<!-- end of auto-generated comment: release notes by coderabbit.ai -->