### PR TITLE
fix(ext-proxy): remove hardcoded default ports

### DIFF
--- a/charts/ext-proxy/Chart.yaml
+++ b/charts/ext-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ext-proxy
 description: A Helm chart for managing different proxy configurations for https://github.com/demeter-run
-version: 0.0.7
+version: 0.0.8
 appVersion: "0.0.1"
 
 maintainers:

--- a/charts/ext-proxy/values.yaml
+++ b/charts/ext-proxy/values.yaml
@@ -35,9 +35,11 @@ proxy:
     requests:
       cpu: "50m"
       memory: "250Mi"
-  ports:
-    metrics: 9187
-    proxy: 8080
+  # Define named ports — keys become containerPort names, values are port numbers.
+  # Example:
+  #   metrics: 9187
+  #   proxy: 8080
+  ports: {}
   affinity: {}
   tolerations: []
 
@@ -52,6 +54,7 @@ init:
 podMonitor:
   enabled: false
   labels: {}
+  # Must match the key name used in proxy.ports for the metrics endpoint.
   metricsPort: metrics
 
 # Extra config files to include in the ConfigMap alongside tiers.toml


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed hardcoded default ports from the `ext-proxy` Helm chart to avoid unintended defaults and make port config explicit. Ports must now be defined as named entries; chart version bumped to 0.0.8.

- **Migration**
  - Define your ports in `proxy.ports` using names (e.g., `metrics: 9187`, `proxy: 8080`).
  - Set `podMonitor.metricsPort` to the name used for the metrics port in `proxy.ports`.

<sup>Written for commit 842621751a1390251aed1f7025617a3f64007b44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proxy and metrics ports are now customizable via configuration.

* **Documentation**
  * Added guidance for configuring port settings to match deployment requirements.

* **Chores**
  * Version updated to 0.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->