### PR TITLE
feat(dolos): bump dolos version and add kupo support

### DIFF
--- a/charts/dolos/Chart.yaml
+++ b/charts/dolos/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dolos
 description: Dolos server
-version: 0.4.5
-appVersion: "1.0.2"
+version: 0.4.6
+appVersion: "1.0.3"
 
 sources:
   - https://github.com/txpipe/dolos

--- a/charts/dolos/templates/headless-service.yaml
+++ b/charts/dolos/templates/headless-service.yaml
@@ -20,3 +20,8 @@ spec:
     - name: minibf
       port: {{ .Values.service.ports.minibf }}
       targetPort: {{ .Values.ports.minibf }}
+    {{- if and .Values.ports.minikupo .Values.service.ports.minikupo }}
+    - name: minikupo
+      port: {{ .Values.service.ports.minikupo }}
+      targetPort: {{ .Values.ports.minikupo }}
+    {{- end }}

--- a/charts/dolos/templates/sts.yaml
+++ b/charts/dolos/templates/sts.yaml
@@ -86,6 +86,11 @@ spec:
             - name: minibf
               containerPort: {{ .Values.ports.minibf }}
               protocol: TCP
+            {{- if and .Values.ports.minikupo .Values.service.ports.minikupo }}
+            - name: minikupo
+              containerPort: {{ .Values.ports.minikupo }}
+              protocol: TCP
+            {{- end }}
         - name: socat-ntc
           image: "{{ .Values.socat.image.repository }}:{{ .Values.socat.image.tag }}"
           imagePullPolicy: {{ .Values.socat.image.pullPolicy | default "IfNotPresent" }}

--- a/charts/dolos/values.yaml
+++ b/charts/dolos/values.yaml
@@ -11,7 +11,7 @@ peerAddress: ""
 # Dolos configuration
 image:
   repository: ghcr.io/txpipe/dolos
-  tag: v1.0.2
+  tag: v1.0.3
   pullPolicy: IfNotPresent
 
 podAnnotations: {}
@@ -29,6 +29,8 @@ ports:
   ouroboros: 30013
   # Mini-Blockfrost API
   minibf: 3001
+  # MiniKupo API (optional, omit to disable)
+  # minikupo: 1442
 
 service:
   # Optional custom service name. If not set, release name will be used.
@@ -38,6 +40,8 @@ service:
     ouroboros: 13013
     # Mini-Blockfrost API
     minibf: 13001
+    # MiniKupo API (required if ports.minikupo is set)
+    # minikupo: 11442
 
 storage:
   # Mainnet requires at least 500Gi
@@ -110,6 +114,10 @@ configmap:
   #   ouroboros:
   #     listen_path: "/ipc/dolos.socket"
   #     magic: 2
+  #   minikupo:
+  #     listen_address: "[::]:1442"
+  #     # Allow cross-origin requests from any origin (set false in production if origin restriction is needed)
+  #     permissive_cors: true
 
   # chain:
   #   type: "cardano"
@@ -134,4 +142,5 @@ configmap:
     # include_grpc: true
     # include_trp: true
     # include_minibf: true
+    # include_minikupo: true
     # include_fjall: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional MiniKupo API configuration and support, including configurable ports and CORS settings.

* **Chores**
  * Bumped Helm chart version to 0.4.6.
  * Updated application version to 1.0.3.
  * Updated container image to v1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `dolos` chart to 0.4.6/app to 1.0.3 and adds optional MiniKupo API support with a new `minikupo` port and config.

- **New Features**
  - Optional `minikupo` port on the StatefulSet and headless Service; off by default and enabled when both `.Values.ports.minikupo` and `.Values.service.ports.minikupo` are set.
  - Example values for `ports.minikupo`, `service.ports.minikupo`, `configmap.http.minikupo` (with `listen_address` and `permissive_cors`), and `configmap.api.include_minikupo`.

- **Dependencies**
  - Image updated to `ghcr.io/txpipe/dolos:v1.0.3`.
  - Chart `version` → 0.4.6 and `appVersion` → 1.0.3.

<sup>Written for commit f4d4176426caeae946e032b15393f9abdd10bfe1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

