### PR TITLE
chore(helmchart): bump dolos version

### DIFF
--- a/charts/dolos/Chart.yaml
+++ b/charts/dolos/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dolos
 description: Dolos server
-version: 0.4.6
-appVersion: "1.0.3"
+version: 0.4.7
+appVersion: "1.1.1"
 
 sources:
   - https://github.com/txpipe/dolos

--- a/charts/dolos/values.yaml
+++ b/charts/dolos/values.yaml
@@ -11,7 +11,7 @@ peerAddress: ""
 # Dolos configuration
 image:
   repository: ghcr.io/txpipe/dolos
-  tag: v1.0.3
+  tag: v1.1.1
   pullPolicy: IfNotPresent
 
 podAnnotations: {}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the `dolos` Helm chart to 0.4.7 and updated `appVersion` and image tag to v1.1.1 to deploy the latest Dolos release. Helm upgrades will pull `ghcr.io/txpipe/dolos:v1.1.1`.

<sup>Written for commit 6e8d3efc6e46c3f46f8a5e15909c75a7031ff4fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart to version 0.4.7
  * Application version updated to 1.1.1
  * Container image tag updated to version 1.1.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->