### PR TITLE
chore(helmchart): bump cardano-node version in preview network

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.8.4
+version: 0.8.5
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/_helpers.tpl
+++ b/charts/cardano-node/templates/_helpers.tpl
@@ -44,6 +44,24 @@ Define Cardano network.
 {{- end -}}
 
 {{/*
+Resolve the image tag, honouring per-network overrides under
+.Values.image.tagOverrides (keyed by cardano_network) and falling back to
+.Values.image.tag.
+*/}}
+{{- define "cardano-node.imageTag" -}}
+{{- $network := include "cardano-node.network" . | trim -}}
+{{- $override := "" -}}
+{{- if .Values.image.tagOverrides -}}
+{{- $override = index .Values.image.tagOverrides $network | default "" -}}
+{{- end -}}
+{{- if $override -}}
+{{ $override }}
+{{- else -}}
+{{ .Values.image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "cardano-node.labels" -}}

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
       initContainers:
       # Download Cardano snapshot using mithril-client
       - name: mithril-snapshot
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.repository }}:{{ include "cardano-node.imageTag" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
@@ -187,7 +187,7 @@ spec:
         - name: CARDANO_SHELLEY_VRF_KEY
           value: "/opt/cardano/config/keys/vrf.skey"
 {{- end }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.repository }}:{{ include "cardano-node.imageTag" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: cardano-node
         ports:
@@ -212,7 +212,7 @@ spec:
 {{- end }}
 
       - name: socat-ntc
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.repository }}:{{ include "cardano-node.imageTag" . }}
         imagePullPolicy: IfNotPresent
         command:
         - socat

--- a/charts/cardano-node/values.yaml
+++ b/charts/cardano-node/values.yaml
@@ -7,6 +7,11 @@ image:
   repository: ghcr.io/blinklabs-io/cardano-node
   tag: 10.5.3
   pullPolicy: IfNotPresent
+  # Per-network tag overrides. If the current cardano_network has an entry
+  # below, that tag is used instead of image.tag. Used to roll out a new
+  # node version on a single network ahead of the others.
+  tagOverrides:
+    preview: 11.0.1
 replicaCount: 1
 resources: {}
 service:


### PR DESCRIPTION
Closes: #377 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped `cardano-node` image to 11.0.1 for the preview network by adding per-network `image.tagOverrides` in the Helm chart. Updated templates to resolve tags per network and bumped the chart to 0.8.5; other networks remain on 10.5.3.

<sup>Written for commit e4951bf912c4aafeaefb33fc256742e9e550d168. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-network Docker image tag overrides in the Helm chart, enabling different container image versions for specific networks (e.g., preview network now uses a different image tag than the default).

* **Chores**
  * Chart version updated to 0.8.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->