### PR TITLE
chore(helms-charts): added enable podmonitor to dolos

### DIFF
--- a/charts/dolos/Chart.yaml
+++ b/charts/dolos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dolos
 description: Dolos server
-version: 0.4.7
+version: 0.5.0
 appVersion: "1.1.1"
 
 sources:

--- a/charts/dolos/templates/podmonitor.yaml
+++ b/charts/dolos/templates/podmonitor.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-podmonitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dolos.labels" . | nindent 4 }}
+    {{- with .Values.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "dolos.selectorLabels" . | nindent 6 }}
+  {{- with .Values.podMonitor.podTargetLabels }}
+  podTargetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  podMetricsEndpoints:
+    {{- if .Values.podMonitor.podMetricsEndpoints }}
+    {{- toYaml .Values.podMonitor.podMetricsEndpoints | nindent 4 }}
+    {{- else }}
+    - port: {{ .Values.podMonitor.port | default "minikupo" }}
+      path: {{ .Values.podMonitor.path | default "/health" }}
+      {{- with .Values.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.podMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      honorLabels: {{ .Values.podMonitor.honorLabels | default false }}
+      {{- if .Values.podMonitor.headers }}
+      headers:
+        {{- toYaml .Values.podMonitor.headers | nindent 8 }}
+      {{- else }}
+      headers:
+        Accept: text/plain
+      {{- end }}
+      {{- with .Values.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/dolos/templates/podmonitor.yaml
+++ b/charts/dolos/templates/podmonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.podMonitor.enabled }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -11,41 +12,15 @@ metadata:
     {{- end }}
 spec:
   selector:
-    matchLabels: {{- include "dolos.selectorLabels" . | nindent 6 }}
+    matchLabels:
+      {{- include "dolos.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   {{- with .Values.podMonitor.podTargetLabels }}
   podTargetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   podMetricsEndpoints:
-    {{- if .Values.podMonitor.podMetricsEndpoints }}
     {{- toYaml .Values.podMonitor.podMetricsEndpoints | nindent 4 }}
-    {{- else }}
-    - port: {{ .Values.podMonitor.port | default "minikupo" }}
-      path: {{ .Values.podMonitor.path | default "/health" }}
-      {{- with .Values.podMonitor.interval }}
-      interval: {{ . }}
-      {{- end }}
-      {{- with .Values.podMonitor.scrapeTimeout }}
-      scrapeTimeout: {{ . }}
-      {{- end }}
-      {{- with .Values.podMonitor.scheme }}
-      scheme: {{ . }}
-      {{- end }}
-      honorLabels: {{ .Values.podMonitor.honorLabels | default false }}
-      {{- if .Values.podMonitor.headers }}
-      headers:
-        {{- toYaml .Values.podMonitor.headers | nindent 8 }}
-      {{- else }}
-      headers:
-        Accept: text/plain
-      {{- end }}
-      {{- with .Values.podMonitor.relabelings }}
-      relabelings:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.podMonitor.metricRelabelings }}
-      metricRelabelings:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- end }}
 {{- end }}

--- a/charts/dolos/values.yaml
+++ b/charts/dolos/values.yaml
@@ -48,6 +48,31 @@ storage:
   size: 50Gi
   # storageClassName: gp
 
+# Prometheus Operator PodMonitor (requires monitoring.coreos.com CRDs)
+podMonitor:
+  enabled: false
+  # Extra labels added to the PodMonitor metadata (e.g. release: kube-prometheus-stack)
+  labels: {}
+  # Pod labels to copy onto the scraped target
+  podTargetLabels: []
+  # Named container port to scrape. Must match a port name on the dolos pod.
+  # The MiniKupo health endpoint is exposed on the `minikupo` port (1442).
+  port: minikupo
+  # Scrape path. Dolos MiniKupo exposes a plaintext /health endpoint.
+  path: /health
+  # interval: 30s
+  # scrapeTimeout: 10s
+  # scheme: http
+  honorLabels: false
+  # Request headers sent on each scrape. MiniKupo /health requires Accept: text/plain.
+  headers:
+    Accept: text/plain
+  # Optional Prometheus relabel configs
+  relabelings: []
+  metricRelabelings: []
+  # If set, fully overrides the default podMetricsEndpoints generated above.
+  podMetricsEndpoints: []
+
 tolerations: []
 
 affinity: {}

--- a/charts/dolos/values.yaml
+++ b/charts/dolos/values.yaml
@@ -55,23 +55,17 @@ podMonitor:
   labels: {}
   # Pod labels to copy onto the scraped target
   podTargetLabels: []
-  # Named container port to scrape. Must match a port name on the dolos pod.
-  # The MiniKupo health endpoint is exposed on the `minikupo` port (1442).
-  port: minikupo
-  # Scrape path. Dolos MiniKupo exposes a plaintext /health endpoint.
-  path: /health
-  # interval: 30s
-  # scrapeTimeout: 10s
-  # scheme: http
-  honorLabels: false
-  # Request headers sent on each scrape. MiniKupo /health requires Accept: text/plain.
-  headers:
-    Accept: text/plain
-  # Optional Prometheus relabel configs
-  relabelings: []
-  metricRelabelings: []
-  # If set, fully overrides the default podMetricsEndpoints generated above.
-  podMetricsEndpoints: []
+  # Scrape endpoints. Each entry must reference a named container port that
+  # exists on the dolos pod. Available named ports: `grpc`, `minibf`, and
+  # (when ports.minikupo is set) `minikupo`.
+  #
+  # The MiniKupo /health endpoint returns plaintext; if you scrape it you must
+  # also set ports.minikupo (e.g. 1442) and service.ports.minikupo so the
+  # `minikupo` container port exists.
+  podMetricsEndpoints:
+    - port: minibf
+      path: /health
+      interval: 30s
 
 tolerations: []
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional `PodMonitor` to the `dolos` Helm chart for Prometheus Operator scraping. It’s disabled by default and configured via values.

- **New Features**
  - Adds `templates/podmonitor.yaml`, gated by `.Values.podMonitor.enabled` (requires `monitoring.coreos.com` CRDs).
  - Configurable: extra labels, `podTargetLabels`, and full `podMetricsEndpoints`; default scrapes port `minibf` at `/health` every 30s. If scraping MiniKupo, also set `ports.minikupo` and `service.ports.minikupo`.
  - Bumps chart version to `0.5.0`.

<sup>Written for commit 128731f9c975dd05ada9eab7cd917e958f57e10d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus Operator integration enabling metrics scraping. Configuration provides flexibility through customizable scraping parameters such as port, endpoint path, headers, timeouts, and relabeling rules. The feature can be easily enabled or disabled per deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->