### PR TITLE
chore: dingo 0.45.0

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.0
-appVersion: 0.23.1
+version: 0.1.1
+appVersion: 0.45.0
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.23.1"
+  tag: "0.45.0"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync


### PR DESCRIPTION
Closes: #382 


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the `dingo` Helm chart to version 0.1.1 and bump `appVersion`/image tag to 0.45.0 so deployments use the latest Dingo release.

<sup>Written for commit dc266e1c64d832fff186585c784f5d5a2c785e01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart to version 0.1.1
  * Updated application to version 0.45.0 with matching container image

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/helm-charts/pull/381)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->