### PR TITLE
Chore: update dingo version version to 0.44.0

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.0
-appVersion: 0.23.1
+version: 0.1.1
+appVersion: 0.45.0
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.1
-appVersion: 0.45.0
+version: 0.1.2
+appVersion: 0.44.0
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.23.1"
+  tag: "0.45.0"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.45.0"
+  tag: "0.44.0"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `dingo` to 0.44.0 for the Helm chart. Sets appVersion and image tag to 0.44.0 and bumps chart version to 0.1.2.

<sup>Written for commit 031667c0e2c474c5129d33c13cf7c991eb602551. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 0.1.2 and application version to 0.44.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/helm-charts/pull/383)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->