### PR TITLE
chore: upgrade dingo 0.46.0

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.2
-appVersion: 0.46.0
+version: 0.1.3
+appVersion: 0.46.1
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.1
-appVersion: 0.45.0
+version: 0.1.2
+appVersion: 0.46.0
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.46.0"
+  tag: "0.46.1"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.45.0"
+  tag: "0.46.0"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync


### PR DESCRIPTION
Closes: #384 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the Dingo Helm chart to use `appVersion` 0.46.1 and image `ghcr.io/blinklabs-io/dingo:0.46.1`; bump chart version to 0.1.3.

<sup>Written for commit 2d2273300e47f6a314da42d7482f599bfd51e64e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application to version 0.46.0
  * Bumped Helm chart version to 0.1.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/helm-charts/pull/385)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->