### PR TITLE
chore: upgrade dingo 0.46.3

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.3
-appVersion: 0.46.1
+version: 0.1.4
+appVersion: 0.46.3
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.46.1"
+  tag: "0.46.3"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync


### PR DESCRIPTION
Closes: #386 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `dingo` to 0.46.3 in the Helm chart so deployments use the latest image `ghcr.io/blinklabs-io/dingo:0.46.3`. Bumps chart version to 0.1.4.

<sup>Written for commit 58fb3335134d1a0e88eca8cd5114c9b6aa76ec19. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/helm-charts/pull/387?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Helm chart version updated to 0.1.4
  * Application version updated to 0.46.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/helm-charts/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->