### PR TITLE
chore: upgrade dingo 0.46.4

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.4
-appVersion: 0.46.3
+version: 0.1.5
+appVersion: 0.46.4
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.46.3"
+  tag: "0.46.4"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync


### PR DESCRIPTION
Closes: #389 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade the `dingo` Helm chart to chart version 0.1.5 and app/image version 0.46.4, updating the `ghcr.io/blinklabs-io/dingo` tag to 0.46.4 to pull in the latest fixes.

<sup>Written for commit 5f12b750daca6b5d57b39f60a8d1c1df4b21565d. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/helm-charts/pull/388?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

