### PR TITLE
chore: upgrade dingo 0.47.1

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.5
-appVersion: 0.46.4
+version: 0.1.6
+appVersion: 0.47.1
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.46.4"
+  tag: "0.47.1"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync


### PR DESCRIPTION
Closes: #390 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade Dingo Helm chart to 0.47.1 to pick up the latest upstream fixes and keep deployments current. Bumps chart version to 0.1.6 and sets appVersion and image to `ghcr.io/blinklabs-io/dingo:0.47.1`.

<sup>Written for commit 8c043b4b7a016c3afa5a7ac937e83a136b74c93b. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/helm-charts/pull/391?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.47.1 in the deployment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/helm-charts/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->