### PR TITLE
fix(tx-submit-api): only render externalTrafficPolicy for external Service types

### DIFF
--- a/charts/tx-submit-api/Chart.yaml
+++ b/charts/tx-submit-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tx-submit-api
 description: Creates a Cardano Tx Submit API deployment
-version: 0.1.20
+version: 0.1.21
 appVersion: 0.20.9
 maintainers:
   - name: aurora

--- a/charts/tx-submit-api/templates/service.yaml
+++ b/charts/tx-submit-api/templates/service.yaml
@@ -25,5 +25,7 @@ spec:
   selector: {{ include "tx-submit-api.selectorLabels" . | nindent 4 }}
   sessionAffinity: ClientIP
   type: {{ .Values.service.type }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Helm service template to only set externalTrafficPolicy for external service types (LoadBalancer, NodePort). Prevents ClusterIP validation errors and bumps chart version to 0.1.21.

<sup>Written for commit 01aeb470a45d3ba8160529b993889481723cc103. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/helm-charts/pull/395?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service configuration is now correctly applied based on service type.

* **Chores**
  * Updated Helm chart version to 0.1.21.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/helm-charts/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->