### PR TITLE
chore: upgrade dingo 0.50.0

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.8
-appVersion: 0.49.1
+version: 0.1.9
+appVersion: 0.50.0
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.49.1"
+  tag: "0.50.0"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `dingo` to 0.50.0 in the Helm chart so deployments use the latest image. Bumps chart version to 0.1.9 and sets appVersion/image tag to 0.50.0.

<sup>Written for commit 01790713bc766bab04ef6c554ee4f9ab4d9e813f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/helm-charts/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version updated to 0.50.0
  * Helm chart version updated to 0.1.9
  * Container image tag synchronized with application version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->