### PR TITLE
chore: chore: upgrade dingo 0.51.0

### DIFF
--- a/charts/dingo/Chart.yaml
+++ b/charts/dingo/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dingo
 description: "A Helm chart for deploying Dingo, the Go Cardano blockchain node"
-version: 0.1.8
-appVersion: 0.49.1
+version: 0.1.9
+appVersion: 0.51.0
 
 sources:
   - https://github.com/blinklabs-io/dingo

--- a/charts/dingo/values.yaml
+++ b/charts/dingo/values.yaml
@@ -6,7 +6,7 @@ updateStrategy:
 
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.49.1"
+  tag: "0.51.0"
   pullPolicy: IfNotPresent
 
 # Native Mithril snapshot bootstrap via dingo's built-in mithril sync


### PR DESCRIPTION
Closes: #398 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade Dingo to v0.51.0 and bump the Helm chart to v0.1.9 to pull the latest image. Deployments now use `ghcr.io/blinklabs-io/dingo:0.51.0`.

<sup>Written for commit d926171c7576416ec131535962da756f3e2bf3c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/helm-charts/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version from 0.1.8 to 0.1.9
  * Bumped application version from 0.49.1 to 0.51.0
  * Updated container image configuration to align with latest application release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->