### PR TITLE
fix(cardano-node): fix cardano node topology json peersnapshotfile

### DIFF
--- a/charts/cardano-node/Chart.yaml
+++ b/charts/cardano-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cardano-node
 description: Creates a Cardano node deployment with SOCAT sidecar
-version: 0.8.4
+version: 0.8.5
 appVersion: 10.5.3
 maintainers:
   - name: aurora

--- a/charts/cardano-node/templates/topology-configmap.yaml
+++ b/charts/cardano-node/templates/topology-configmap.yaml
@@ -30,7 +30,8 @@ data:
         }
       {{- end }}
       ]
-      {{- with .Values.topology.peerSnapshotFile }},
+      {{- with .Values.topology.peerSnapshotFile }}
+      ,
       "peerSnapshotFile": {{ . | toJson }}
       {{- end }},
       "publicRoots": [{{- $publicIndex := 0 }}


### PR DESCRIPTION
Closes: #353 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes JSON rendering in the `cardano-node` topology ConfigMap by correctly placing a comma before the optional `peerSnapshotFile` field, preventing malformed JSON when `topology.peerSnapshotFile` is set. Bumps chart version to `0.8.5`.

<sup>Written for commit 1d526566f7eb9e21e6a51ab68a0149534d39405a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/helm-charts/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

