### PR TITLE
chore: upgrade dolos version to V1.2.0

### DIFF
--- a/charts/dolos/Chart.yaml
+++ b/charts/dolos/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dolos
 description: Dolos server
-version: 0.5.0
-appVersion: "1.1.1"
+version: 0.5.1
+appVersion: "1.2.0"
 
 sources:
   - https://github.com/txpipe/dolos

--- a/charts/dolos/values.yaml
+++ b/charts/dolos/values.yaml
@@ -11,7 +11,7 @@ peerAddress: ""
 # Dolos configuration
 image:
   repository: ghcr.io/txpipe/dolos
-  tag: v1.1.1
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 
 podAnnotations: {}


### PR DESCRIPTION
Closes: #403 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrades the Dolos Helm chart to 0.5.1 and updates the image to `ghcr.io/txpipe/dolos:v1.2.0` so deployments use Dolos 1.2.0.

<sup>Written for commit 59dffe2fca0a74a2394f787b168d1bb3ab4c7dd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/helm-charts/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

